### PR TITLE
Closes #243: Return more user friendly error messages throughout

### DIFF
--- a/atr/blueprints/admin/admin.py
+++ b/atr/blueprints/admin/admin.py
@@ -270,7 +270,7 @@ async def admin_data(model: str = "Committee") -> str:
 async def admin_delete_test_openpgp_keys() -> quart.Response | response.Response:
     """Delete all test user OpenPGP keys and their links."""
     if not config.get().ALLOW_TESTS:
-        raise base.ASFQuartException("Test key deletion not enabled", errorcode=404)
+        raise base.ASFQuartException("Test operations are disabled in this environment", errorcode=403)
 
     test_uid = "test"
 

--- a/atr/routes/draft.py
+++ b/atr/routes/draft.py
@@ -190,7 +190,10 @@ async def hashgen(
     form = await quart.request.form
     hash_type = form.get("hash_type")
     if hash_type not in {"sha256", "sha512"}:
-        raise base.ASFQuartException("Invalid hash type", errorcode=400)
+        raise base.ASFQuartException(
+            f"Invalid hash type '{hash_type}'. Supported types: sha256, sha512", 
+            errorcode=400
+        )
 
     rel_path = pathlib.Path(file_path)
 
@@ -224,7 +227,10 @@ async def sbomgen(
 
     # Check that the file is a .tar.gz archive before creating a revision
     if not (file_path.endswith(".tar.gz") or file_path.endswith(".tgz")):
-        raise base.ASFQuartException("SBOM generation is only supported for .tar.gz files", errorcode=400)
+        raise base.ASFQuartException(
+            f"SBOM generation requires .tar.gz or .tgz files. Received: {file_path}",
+            errorcode=400
+        )
 
     try:
         description = "SBOM generation through web interface"

--- a/atr/routes/keys.py
+++ b/atr/routes/keys.py
@@ -497,9 +497,15 @@ async def _get_keys_text(keys_url: str, render: Callable[[str], Awaitable[str]])
                 response.raise_for_status()
                 return await response.text()
     except aiohttp.ClientResponseError as e:
-        raise base.ASFQuartException(f"Error fetching URL: {e.status} {e.message}")
+        raise base.ASFQuartException(
+                f"Unable to fetch keys from remote server: {e.status} {e.message}",
+                errorcode=502
+            )
     except aiohttp.ClientError as e:
-        raise base.ASFQuartException(f"Error fetching URL: {e}")
+        raise base.ASFQuartException(
+                f"Network error while fetching keys: {e}",
+                errorcode=503
+            )
 
 
 async def _key_and_is_owner(

--- a/atr/util.py
+++ b/atr/util.py
@@ -926,7 +926,10 @@ def validate_as_type[T](value: Any, t: type[T]) -> T:
 async def validate_empty_form() -> None:
     empty_form = await forms.Empty.create_form(data=await quart.request.form)
     if not await empty_form.validate_on_submit():
-        raise base.ASFQuartException("Invalid request", 400)
+        raise base.ASFQuartException(
+            "Invalid form submission. Please check your input and try again.",
+            errorcode=400
+        )
 
 
 def validate_vote_duration(form: wtforms.Form, field: wtforms.IntegerField) -> None:


### PR DESCRIPTION
This PR addresses issue #243 by making error messages more user-friendly throughout the codebase.
I focused on rewriting vague or generic messages to be more explicit, actionable, and helpful, while also adjusting a few status codes to better reflect the nature of the errors.

No instances were found where 5xx codes were incorrectly used instead of 4xx (e.g., no 500 for permissions errors), so those weren't modified.