### PR TITLE
Make the distribution forms more type safe

### DIFF
--- a/atr/models/distribution.py
+++ b/atr/models/distribution.py
@@ -87,21 +87,6 @@ class PyPIResponse(schema.Lax):
     info: PyPIInfo = pydantic.Field(default_factory=PyPIInfo)
 
 
-class DeleteData(schema.Lax):
-    release_name: str
-    platform: sql.DistributionPlatform
-    owner_namespace: str
-    package: str
-    version: str
-
-    @pydantic.field_validator("platform", mode="before")
-    @classmethod
-    def coerce_platform(cls, v: object) -> object:
-        if isinstance(v, str):
-            return sql.DistributionPlatform[v]
-        return v
-
-
 # Lax to ignore csrf_token and submit
 # WTForms types platform as Any, which is insufficient
 # And this way we also get nice JSON from the Pydantic model dump

--- a/atr/post/distribution.py
+++ b/atr/post/distribution.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-import quart
-
 import atr.blueprints.post as post
 import atr.db as db
 import atr.get as get
@@ -29,25 +27,29 @@ import atr.web as web
 
 
 @post.committer("/distribution/delete/<project>/<version>")
-async def delete(session: web.Committer, project: str, version: str) -> web.WerkzeugResponse:
-    form = await shared.distribution.DeleteForm.create_form(data=await quart.request.form)
-    dd = distribution.DeleteData.model_validate(form.data)
+@post.form(shared.distribution.DeleteForm)
+async def delete(
+    session: web.Committer, delete_form: shared.distribution.DeleteForm, project: str, version: str
+) -> web.WerkzeugResponse:
+    sql_platform = delete_form.platform.to_sql()  # type: ignore[attr-defined]
 
     # Validate the submitted data, and obtain the committee for its name
     async with db.session() as data:
-        release = await data.release(name=dd.release_name).demand(RuntimeError(f"Release {dd.release_name} not found"))
-    committee = release.committee
-    if committee is None:
-        raise RuntimeError(f"Release {dd.release_name} has no committee")
+        release = await data.release(name=delete_form.release_name).demand(
+            RuntimeError(f"Release {delete_form.release_name} not found")
+        )
+        committee = release.committee
+        if committee is None:
+            raise RuntimeError(f"Release {delete_form.release_name} has no committee")
 
     # Delete the distribution
     async with storage.write_as_committee_member(committee_name=committee.name) as wacm:
         await wacm.distributions.delete_distribution(
-            release_name=dd.release_name,
-            platform=dd.platform,
-            owner_namespace=dd.owner_namespace,
-            package=dd.package,
-            version=dd.version,
+            release_name=delete_form.release_name,
+            platform=sql_platform,
+            owner_namespace=delete_form.owner_namespace,
+            package=delete_form.package,
+            version=delete_form.version,
         )
     return await session.redirect(
         get.distribution.list_get,
@@ -58,33 +60,64 @@ async def delete(session: web.Committer, project: str, version: str) -> web.Werk
 
 
 @post.committer("/distribution/record/<project>/<version>")
-async def record_post(session: web.Committer, project: str, version: str) -> str:
-    form = await shared.distribution.DistributeForm.create_form(data=await quart.request.form)
-    fpv = shared.distribution.FormProjectVersion(form=form, project=project, version=version)
-    if await form.validate():
-        return await shared.distribution.record_form_process_page(fpv)
-    match len(form.errors):
-        case 0:
-            # Should not happen
-            await quart.flash("Ambiguous submission errors", category="warning")
-        case 1:
-            await quart.flash("There was 1 submission error", category="error")
-        case _ as n:
-            await quart.flash(f"There were {n} submission errors", category="error")
-    return await shared.distribution.record_form_page(fpv)
+@post.form(shared.distribution.DistributeForm)
+async def record_selected(
+    session: web.Committer, distribute_form: shared.distribution.DistributeForm, project: str, version: str
+) -> web.WerkzeugResponse:
+    return await record_form_process_page(session, distribute_form, project, version, staging=False)
 
 
 @post.committer("/distribution/stage/<project>/<version>")
-async def stage_post(session: web.Committer, project: str, version: str) -> str:
-    form = await shared.distribution.DistributeForm.create_form(data=await quart.request.form)
-    fpv = shared.distribution.FormProjectVersion(form=form, project=project, version=version)
-    if await form.validate():
-        return await shared.distribution.record_form_process_page(fpv, staging=True)
-    match len(form.errors):
-        case 0:
-            await quart.flash("Ambiguous submission errors", category="warning")
-        case 1:
-            await quart.flash("There was 1 submission error", category="error")
-        case _ as n:
-            await quart.flash(f"There were {n} submission errors", category="error")
-    return await shared.distribution.record_form_page(fpv, staging=True)
+@post.form(shared.distribution.DistributeForm)
+async def stage_selected(
+    session: web.Committer, distribute_form: shared.distribution.DistributeForm, project: str, version: str
+) -> web.WerkzeugResponse:
+    return await record_form_process_page(session, distribute_form, project, version, staging=True)
+
+
+async def record_form_process_page(
+    session: web.Committer,
+    form_data: shared.distribution.DistributeForm,
+    project: str,
+    version: str,
+    /,
+    staging: bool = False,
+) -> web.WerkzeugResponse:
+    sql_platform = form_data.platform.to_sql()  # type: ignore[attr-defined]
+    dd = distribution.Data(
+        platform=sql_platform,
+        owner_namespace=form_data.owner_namespace,
+        package=form_data.package,
+        version=form_data.version,
+        details=form_data.details,
+    )
+    release, committee = await shared.distribution.release_validated_and_committee(
+        project,
+        version,
+        staging=staging,
+    )
+
+    async with storage.write_as_committee_member(committee_name=committee.name) as w:
+        try:
+            _dist, added, _metadata = await w.distributions.record_from_data(
+                release=release,
+                staging=staging,
+                dd=dd,
+            )
+        except storage.AccessError as e:
+            # Instead of calling record_form_page_new, redirect with error message
+            return await session.redirect(
+                get.distribution.stage if staging else get.distribution.record,
+                project=project,
+                version=version,
+                error=str(e),
+            )
+
+    # Success - redirect to distribution list with success message
+    message = "Distribution recorded successfully." if added else "Distribution was already recorded."
+    return await session.redirect(
+        get.distribution.list_get,
+        project=project,
+        version=version,
+        success=message,
+    )

--- a/atr/storage/writers/distributions.py
+++ b/atr/storage/writers/distributions.py
@@ -25,6 +25,7 @@ import aiohttp
 import sqlalchemy.exc as exc
 
 import atr.db as db
+import atr.log as log
 import atr.models.basic as basic
 import atr.models.distribution as distribution
 import atr.models.sql as sql
@@ -161,8 +162,9 @@ class CommitteeMember(CommitteeParticipant):
         match api_oc:
             case outcome.Result(result):
                 pass
-            case outcome.Error():
-                raise storage.AccessError("Failed to get API response from distribution platform")
+            case outcome.Error(error):
+                log.error(f"Failed to get API response from {api_url}: {error}")
+                raise storage.AccessError(f"Failed to get API response from distribution platform: {error}")
         upload_date = self.__distribution_upload_date(dd.platform, result, dd.version)
         if upload_date is None:
             raise storage.AccessError("Failed to get upload date from distribution platform")


### PR DESCRIPTION
Following established pattern to use Pydantic, moving from `forms.py` to `form.py`.