### PR TITLE
Add markdownlint with pre-commit

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,17 @@
+MD004:
+  style: consistent
+
+MD013:
+  code_blocks: false
+  line_length: 915
+  tables: false
+
+MD033: false
+
+MD034: false
+
+MD040: false
+
+MD041: false
+
+MD046: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,15 @@ repos:
         - --license-filepath
         - scripts/ci/LICENSE-template.txt
         - --fuzzy-match-generates-todo
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.46.0
+  hooks:
+    - id: markdownlint
+      name: run markdownlint
+      description: check Markdown files with markdownlint
+      args: [--config=.github/linters/.markdown-lint.yml]
+      types: [markdown]
+      files: \.md$
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.11.0.1
   hooks:

--- a/Alpha-signup.md
+++ b/Alpha-signup.md
@@ -1,16 +1,17 @@
-## Alpha test PMCs
+# Alpha test PMCs
 
 Please try the ATR at https://release-test.apache.org/. This is a playground to make sure
 that we are properly considering every project's release policies and workflows while we
 continue development.
 
 You can provide feedback via
+
 1. https://github.com/apache/tooling-trusted-releases/issues
 2. mailto:dev@tooling.apache.org
 3. ASF Slack - [#apache-trusted-releases](https://the-asf.slack.com/archives/C049WADAAQG)
 
-| PMC | PMC Members | Release and Project Description |
-|-----|-------------|---------------------------------|
-| Arrow | Jacob Wujciak |                             |
+| PMC   | PMC Members   | Release and Project Description |
+|-------|---------------|---------------------------------|
+| Arrow | Jacob Wujciak |                                 |
 
 Submit a PR to add a table row for your PMC.

--- a/atr/docs/code-conventions.md
+++ b/atr/docs/code-conventions.md
@@ -71,10 +71,10 @@ Prefix all private interfaces, e.g. functions, classes, constants, variables, wi
 
 Exceptions to this rule include:
 
-- Type variables
-- Enumerations
-- Methods requiring interface compatibility with their superclass
-- Nested functions (which should generally be avoided)
+* Type variables
+* Enumerations
+* Methods requiring interface compatibility with their superclass
+* Nested functions (which should generally be avoided)
 
 Scripts are explicitly _not_ an exception. Underscores should be used to prefix private interfaces in scripts for consistency, e.g. so that linters don't need to carry exceptions, and to ease potential migration to modules.
 
@@ -206,8 +206,8 @@ Our use of blockbuster enables automatic detection of synchronous function calls
 
 Exceptions to this rule apply only in these scenarios:
 
-- When dealing with third party dependencies
-- When the asynchronous equivalent function is unknown
+* When dealing with third party dependencies
+* When the asynchronous equivalent function is unknown
 
 If either exception applies, either submit a brief issue with the blockbuster traceback, notify the team via Slack, or add a code comment if part of another commit. An ATR Tooling engineer will address the issue without requiring significant time investment from you.
 

--- a/atr/docs/how-to-contribute.md
+++ b/atr/docs/how-to-contribute.md
@@ -54,15 +54,15 @@ You can also [email patches](https://lists.apache.org/list.html?dev@tooling.apac
 
 We follow a consistent style for commit messages. The first line of the commit message is called the subject line, and should follow these guidelines:
 
-- **Use the imperative mood.** The subject line should complete the sentence "If applied, this commit will...".
-- **Use sentence case.** Start with a capital letter, but do not use a full stop at the end.
-- **Use articles as appropriate before nouns**. Write about "a feature" not just "feature". Say, for example, "fix a bug", and not "fix bug".
-- **Be specific and descriptive.** Prefer "Fix a bug in vote resolution for tied votes" to "Fix a bug" or "Update the vote code".
-- **Keep it concise.** Aim for 50 to 72 characters. If you need more space to explain your changes, use the commit body.
+* **Use the imperative mood.** The subject line should complete the sentence "If applied, this commit will...".
+* **Use sentence case.** Start with a capital letter, but do not use a full stop at the end.
+* **Use articles as appropriate before nouns**. Write about "a feature" not just "feature". Say, for example, "fix a bug", and not "fix bug".
+* **Be specific and descriptive.** Prefer "Fix a bug in vote resolution for tied votes" to "Fix a bug" or "Update the vote code".
+* **Keep it concise.** Aim for 50 to 72 characters. If you need more space to explain your changes, use the commit body.
 
 **Examples of good subject lines:**
 
-```
+```cmd
 Add distribution platform validation to the compose phase
 Fix a bug with sorting version numbers containing release candidates
 Move code to delete releases to the storage interface
@@ -71,7 +71,7 @@ Update dependencies
 
 **Examples of poor subject lines:**
 
-```
+```cmd
 fixed stuff
 Updated the code.
 refactoring vote resolution logic
@@ -105,11 +105,11 @@ ATR is developed by ASF Tooling, which is an initiative of the ASF rather than a
 
 The primary goal of ATR is to deter and minimize supply chain attacks on ASF software releases. Since security is our highest priority, we scrutinize all contributions for potential vulnerabilities. To assist us when you make a contribution, please:
 
-- Follow secure coding practices. Review best practice guidelines to learn how to avoid vulnerabilities such as injection attacks, cross-site scripting, and insecure deserialization.
-- Validate all user inputs and sanitize all outputs.
-- Use well established, independently audited, and actively maintained libraries rather than implementing cryptographic or security sensitive functionality yourself.
-- Always consider the security implications of your changes. If you are unsure of the implications of your changes, ask the team for guidance.
-- Report any security issues you discover in ATR responsibly. Do not open a public issue for security vulnerabilities. Instead, follow the [ASF security reporting process](https://www.apache.org/security/).
+* Follow secure coding practices. Review best practice guidelines to learn how to avoid vulnerabilities such as injection attacks, cross-site scripting, and insecure deserialization.
+* Validate all user inputs and sanitize all outputs.
+* Use well established, independently audited, and actively maintained libraries rather than implementing cryptographic or security sensitive functionality yourself.
+* Always consider the security implications of your changes. If you are unsure of the implications of your changes, ask the team for guidance.
+* Report any security issues you discover in ATR responsibly. Do not open a public issue for security vulnerabilities. Instead, follow the [ASF security reporting process](https://www.apache.org/security/).
 
 ### High quality standards
 
@@ -123,9 +123,9 @@ We strongly encourage all contributors to enable two-factor authentication on th
 
 If you have questions about contributing to ATR, or if you need help with any step of the contribution process, please reach out to the team. You can:
 
-- Ask questions on the [dev mailing list](https://lists.apache.org/list.html?dev@tooling.apache.org), which is the primary forum for ATR development discussions.
-- Comment on the relevant issue or pull request in the [issue tracker](https://github.com/apache/tooling-trusted-releases/issues).
-- Chat with us in the [#apache-trusted-releases channel](https://the-asf.slack.com/archives/C049WADAAQG) on ASF Slack.
-- Read the rest of the [developer guide](developer-guide) for detailed information about how ATR works and how to make changes to it.
+* Ask questions on the [dev mailing list](https://lists.apache.org/list.html?dev@tooling.apache.org), which is the primary forum for ATR development discussions.
+* Comment on the relevant issue or pull request in the [issue tracker](https://github.com/apache/tooling-trusted-releases/issues).
+* Chat with us in the [#apache-trusted-releases channel](https://the-asf.slack.com/archives/C049WADAAQG) on ASF Slack.
+* Read the rest of the [developer guide](developer-guide) for detailed information about how ATR works and how to make changes to it.
 
 We welcome all types of contribution, and are happy to help you get started. Thank you for your interest in contributing to ATR.

--- a/atr/docs/user-interface.md
+++ b/atr/docs/user-interface.md
@@ -75,16 +75,16 @@ The [`form.label`](/ref/atr/form.py:label) function is used to add metadata to P
 
 Fields use Pydantic type annotations to define their data type:
 
-- `str` - text input (default widget: `Widget.TEXT`)
-- `form.Email` - email input with validation
-- `form.URL` - URL input with validation
-- `form.Bool` - checkbox
-- `form.Int` - number input
-- `form.StrList` - multiple checkboxes that collect strings
-- `form.File` - single file upload
-- `form.FileList` - multiple file upload
-- `form.Enum[EnumType]` - dropdown select from enum values
-- `form.Set[EnumType]` - multiple checkboxes from enum values
+* `str` - text input (default widget: `Widget.TEXT`)
+* `form.Email` - email input with validation
+* `form.URL` - URL input with validation
+* `form.Bool` - checkbox
+* `form.Int` - number input
+* `form.StrList` - multiple checkboxes that collect strings
+* `form.File` - single file upload
+* `form.FileList` - multiple file upload
+* `form.Enum[EnumType]` - dropdown select from enum values
+* `form.Set[EnumType]` - multiple checkboxes from enum values
 
 Empty values for fields are allowed by default in most cases, but URL is an exception.
 
@@ -171,13 +171,13 @@ The `defaults` parameter accepts a dictionary to populate initial field values. 
 
 Key rendering parameters:
 
-- `action` - form submission URL (defaults to current path)
-- `submit_label` - text for the submit button
-- `cancel_url` - if provided, adds a cancel link next to submit
-- `defaults` - dictionary of initial values or dynamic choices
-- `textarea_rows` - number of rows for textarea widgets (default: 12)
-- `wider_widgets` - use wider input column (default: False)
-- `border` - add borders between fields (default: False)
+* `action` - form submission URL (defaults to current path)
+* `submit_label` - text for the submit button
+* `cancel_url` - if provided, adds a cancel link next to submit
+* `defaults` - dictionary of initial values or dynamic choices
+* `textarea_rows` - number of rows for textarea widgets (default: 12)
+* `wider_widgets` - use wider input column (default: False)
+* `border` - add borders between fields (default: False)
 
 ## Programmatic HTML
 

--- a/atr/policy/third-party-licenses.md
+++ b/atr/policy/third-party-licenses.md
@@ -1,27 +1,27 @@
-Title: ASF 3rd Party License Policy
+Title: ASF 3rd Party License Policy <!-- markdownlint-disable-line MD041 -->
 license: https://www.apache.org/licenses/LICENSE-2.0
-
-
 
 [TOC]
 
 ## Purpose  {#audience}
+
 This policy provides licensing guidance to Apache Software Foundation projects. It identifies the acceptable
 licenses for inclusion of third-party Open Source components in Apache Software Foundation products.
 
 Projects can submit licensing questions to the Legal Affairs Committee
 [JIRA space](https://issues.apache.org/jira/browse/LEGAL).
 
-
 ### License Criteria  {#criteria}
+
 The following criteria serve as guidelines for the categories on this page.
 
 1. The license must meet the [Open Source Definition](https://opensource.org/osd-annotated).<sup>a</sup>
 2. The license, as applied in practice, must not impose significant restrictions beyond those imposed by the Apache License 2.0.
 
-<sub>*a. (reviewed: 2019-02-16)*</sub>
+<sub>*a. (reviewed: 2019-02-16)*</sub> <!-- markdownlint-disable-line MD036 -->
 
 ### High Level  {#highlevel}
+
 At a high level this policy separates licenses into three categories.
 
 - **Category A**: Licenses in Category A may be included in Apache Software Foundation products. They are said to be "Apache-like".
@@ -35,31 +35,31 @@ For inclusion in an Apache Software Foundation product, we consider the followin
 - [Apache License 2.0](/licenses/LICENSE-2.0 "Category A: Apache-2.0")
 - [Apache Software License 1.1](/licenses/LICENSE-1.1 "Category A: Apache-1.1").
   Including variants:
-    - [PHP License 3.01](http://www.php.net/license/3_01.txt "Category A: PHP-3.01")
-    - [MX4J License](http://mx4j.sourceforge.net/docs/ch01s06.html "Category A: LicenseRef-MX4J")
+  - [PHP License 3.01](http://www.php.net/license/3_01.txt "Category A: PHP-3.01")
+  - [MX4J License](http://mx4j.sourceforge.net/docs/ch01s06.html "Category A: LicenseRef-MX4J")
 - BSD (without advertising clause). Including variants:
-    - [BSD 2-clause](http://opensource.org/licenses/bsd-license.php "Category A: BSD-2-Clause")
-    - [BSD 3-clause](http://opensource.org/licenses/BSD-3-Clause "Category A: BSD-3-Clause")
-    - [DOM4J License](https://github.com/dom4j/dom4j/blob/master/LICENSE "Category A: LicenseRef-DOM4J")
-    - [PostgreSQL License](http://opensource.org/licenses/postgresql "Category A: PostgreSQL")
-    - [Eclipse Distribution License 1.0](http://www.eclipse.org/org/documents/edl-v10.php "Category A: BSD-3-Clause")
-    - [Lawrence Berkeley National Labs BSD](https://spdx.org/licenses/BSD-3-Clause-LBNL.html "Category A: BSD-3-Clause-LBNL")
+  - [BSD 2-clause](http://opensource.org/licenses/bsd-license.php "Category A: BSD-2-Clause")
+  - [BSD 3-clause](http://opensource.org/licenses/BSD-3-Clause "Category A: BSD-3-Clause")
+  - [DOM4J License](https://github.com/dom4j/dom4j/blob/master/LICENSE "Category A: LicenseRef-DOM4J")
+  - [PostgreSQL License](http://opensource.org/licenses/postgresql "Category A: PostgreSQL")
+  - [Eclipse Distribution License 1.0](http://www.eclipse.org/org/documents/edl-v10.php "Category A: BSD-3-Clause")
+  - [Lawrence Berkeley National Labs BSD](https://spdx.org/licenses/BSD-3-Clause-LBNL.html "Category A: BSD-3-Clause-LBNL")
 - [MIT/X11](http://opensource.org/licenses/mit-license.php "Category A: MIT")
-    - [ISC](https://opensource.org/licenses/ISC "Category A: ISC")
-    - [Standard ML of New Jersey](https://www.smlnj.org/license.html "Category A: SMLNJ")
-    - [Cup Parser Generator](http://www2.cs.tum.edu/projects/cup/licence.php "Category A: LicenseRef-CupPG")
-    - [MIT No Attribution (MIT-0)](https://opensource.org/license/mit-0/ "Category A: MIT-0")
+  - [ISC](https://opensource.org/licenses/ISC "Category A: ISC")
+  - [Standard ML of New Jersey](https://www.smlnj.org/license.html "Category A: SMLNJ")
+  - [Cup Parser Generator](http://www2.cs.tum.edu/projects/cup/licence.php "Category A: LicenseRef-CupPG")
+  - [MIT No Attribution (MIT-0)](https://opensource.org/license/mit-0/ "Category A: MIT-0")
 - [ICU](http://source.icu-project.org/repos/icu/icu/trunk/LICENSE "Category A: ICU")
 - [University of Illinois/NCSA](http://opensource.org/licenses/UoI-NCSA.php "Category A: NCSA")
 - [W3C Software License](http://opensource.org/licenses/W3C.php "Category A: W3C")
 - [W3C Community Contributor License Agreement](https://www.w3.org/community/about/agreements/cla/ "Category A: LicenseRef-W3C-CCLA") - if at least 45 days after publication</li>
 - [X.Net](https://opensource.org/license/xnet "Category A: Xnet")
 - [zlib](http://opensource.org/licenses/zlib-license.php "Category A: Zlib")/[libpng](https://spdx.org/licenses/Libpng.html "Category A: Libpng")
-- [FSF autoconf license](# "Category A: FSFAP")
+- [FSF autoconf license](# "Category A: FSFAP") <!-- markdownlint-disable-line MD042 -->
 - [DejaVu Fonts (Bitstream Vera/Arev licenses)](https://spdx.org/licenses/Bitstream-Vera.html "Category A: Bitstream-Vera")
 - [Academic Free License 3.0](http://opensource.org/licenses/afl-3.0.php "Category A: AFL-3.0")
 - [Service+Component+Architecture+Specifications](http://web.archive.org/web/20080704184203/http://www.osoa.org/xmlns/sca/1.0/license.txt "Category A: LicenseRef-SCA-Spec")
-- [OOXML XSD ECMA License](# "Category A: LicenseRef-ECMA-OOXML-XSD")
+- [OOXML XSD ECMA License](# "Category A: LicenseRef-ECMA-OOXML-XSD") <!-- markdownlint-disable-line MD042 -->
 - [Microsoft Public License (MsPL)](http://www.opensource.org/licenses/ms-pl.html "Category A: MS-PL")
 - [Creative Commons Copyright-Only Dedication](http://creativecommons.org/licenses/publicdomain/ "Category A: CC-PDDC")
 - [Python Software Foundation License](http://www.opensource.org/licenses/PythonSoftFoundation.php "Category A: Python-2.0")
@@ -93,28 +93,28 @@ You can include works in the public domain (or covered by a license treated simi
 
 A work should be treated as being in the public domain when one of the following applies:
 
-  - the work is covered by
-       - the Creative Commons [Public Domain Mark](http://creativecommons.org/publicdomain/mark/1.0/ "Category A: CC-PDM-1.0")
-       - a suitable dedication (to the public domain) by the authors
-  - clear evidence exists that US copyright for the work
-      - has expired
-      - cannot be claimed.
+- the work is covered by
+  - the Creative Commons [Public Domain Mark](http://creativecommons.org/publicdomain/mark/1.0/ "Category A: CC-PDM-1.0")
+  - a suitable dedication (to the public domain) by the authors
+- clear evidence exists that US copyright for the work
+  - has expired
+  - cannot be claimed.
 
 Licenses that we treat as similar to public domain:
 
-  - Creative Commons [CC0 “No Rights Reserved”](http://creativecommons.org/about/cc0 "Category A: CC0-1.0")
-  - Creative Commons [Public Domain Certification](http://creativecommons.org/licenses/publicdomain/ "Category A: CC-PDDC")
+- Creative Commons [CC0 “No Rights Reserved”](http://creativecommons.org/about/cc0 "Category A: CC0-1.0")
+- Creative Commons [Public Domain Certification](http://creativecommons.org/licenses/publicdomain/ "Category A: CC-PDDC")
 
 **Note that** whether a work falls in the public domain may be a
 [difficult](http://fairuse.stanford.edu/Copyright_and_Fair_Use_Overview/chapter8/) subject.
 Determining whether the copyright in a work has expired may be non-trivial and may vary between jurisdictions. Raise the topic on legal-discuss@ or via a JIRA issue if you have doubt over whether a work falls in the public domain.
-
 
 ## Category B: What can we *maybe* include in an ASF Project?  {#category-b}
 
 You may include the licenses and/or projects described in this section in an Apache Software Foundation product **IF** they meet the specified conditions.
 
 ### Appropriately Labelled Condition
+
 In all Category B cases our users should not be surprised at their inclusion in our products.
 If we attach an appropriate and prominent label to the distribution,
 users are less likely to be unaware of restrictions significantly
@@ -125,6 +125,7 @@ its licensing, and provide a url to the its homepage. Please also comply with
 any attribution/notice requirements in the specific license in question.
 
 ### Binary-only Inclusion Condition
+
 Any Category B licensed works may be included in binary-only form in Apache Software Foundation convenience binaries.
 Do not include Category B licensed works in source releases.
 
@@ -165,6 +166,7 @@ standard), you may include appropriately labeled source code. An example of this
 inclusion is mandated by the JSR 127: JavaServer Faces specification.
 
 ### Including Creative Commons Attribution content  {#cc-by}
+
 Works under the [Creative Commons Attribution (CC-BY)](http://creativecommons.org/licenses/by/4.0/ "Category B: CC-BY-4.0") licenses ([2.5](http://creativecommons.org/licenses/by/2.5/ "Category B: CC-BY-2.5"), [3.0](http://creativecommons.org/licenses/by/3.0/ "Category B: CC-BY-3.0"), and 4.0)
 contain terms related to "Effective Technological Measures", which may come as a surprise to users. Thus you should label them appropriately and only include them in binary form.
 
@@ -233,10 +235,10 @@ its typical use.
 To date, we have approved the following tools for such use:
 
 - The Autotools family of products, specifically:
-    - [Autoconf](http://www.gnu.org/software/autoconf/)
-    - [Automake](http://www.gnu.org/software/automake/)
-    - [Libtool](http://www.gnu.org/software/libtool/)
-    - [mkinstalldirs.sh](http://www.gnu.org/software/hello/manual/gettext/mkinstalldirs.html)
+  - [Autoconf](http://www.gnu.org/software/autoconf/)
+  - [Automake](http://www.gnu.org/software/automake/)
+  - [Libtool](http://www.gnu.org/software/libtool/)
+  - [mkinstalldirs.sh](http://www.gnu.org/software/hello/manual/gettext/mkinstalldirs.html)
 - [OCamlMakefile](http://hg.ocaml.info/release/ocaml-make/)
 - [setup.rb](http://i.loveruby.net/en/projects/setup/)
 
@@ -262,44 +264,43 @@ Also note that the Ruby license is listed on the 'Category B' Weak Copyleft list
 
 From Java 9 onwards, Javadoc can include JavaScript under MIT, MIT OR GPL-3.0, or GPL-2.0 WITH ClasspathException-2.0. Apache binary releases (including Maven javadoc jars) and Apache websites may include this for their javadoc. It must not be included in source releases.
 
-
 ## Category X: What can we NOT include in an ASF Project?  {#category-x}
 
 You may NOT include the following licenses within Apache products:
 
 - Not OSD-compliant:
-    - [Binary Code License (BCL)](# "Category X: LicenseRef-BCL")
-    - [Intel Simplified Software License](https://software.intel.com/en-us/license/intel-simplified-software-license "Category X: LicenseRef-Intel-SSL")
-    - [JSR-275 License](https://github.com/unitsofmeasurement/jsr-275/blob/0.9.3/LICENSE.txt "Category X: LicenseRef-JSR-275")
-    - Field of use restrictions:
-        - [Microsoft Limited Public License](https://www.openhub.net/licenses/mslpl "Category X: MS-LPL")
-        - [Amazon Software License (ASL)](https://aws.amazon.com/asl/ "Category X: LicenseRef-Amazon-Software-License")
-        - [Java SDK for Satori RTM license](https://github.com/satori-com/satori-rtm-sdk-java/blob/master/LICENSE "Category X: LicenseRef-Java-SDK-for-Satori-RTM")
-        - [Redis Source Available License (RSAL)](https://redislabs.com/community/licenses/ "Category X: LicenseRef-Redis-Source-Available")
-        - [Booz Allen Public License](http://boozallen.github.io/licenses/bapl "Category X: LicenseRef-Booz-Allen-Public-License")
-        - [Confluent Community License Version 1.0](https://www.confluent.io/confluent-community-license/ "Category X: LicenseRef-Confluent-Community-1.0")
-        - [Business Source License 1.1](https://spdx.org/licenses/BUSL-1.1.html "Category X: BUSL-1.1")
-        - Any license including the [Commons Clause License Condition v1.0](https://commonsclause.com "Category X: LicenseRef-Commons-Clause-1.0")
-    - Non-commercial licenses:
-        - [Creative Commons Non-Commercial](https://en.wikipedia.org/wiki/Creative_Commons_license#Non-commercial_licenses "Category X: CC-BY-NC-4.0") variants
-        - [Sun Community Source License 3.0](http://jcp.org/aboutJava/communityprocess/SCSL3.0.rtf "Category X: LicenseRef-Sun-Community-Source-3.0")
+  - [Binary Code License (BCL)](# "Category X: LicenseRef-BCL") <!-- markdownlint-disable-line MD042 -->
+  - [Intel Simplified Software License](https://software.intel.com/en-us/license/intel-simplified-software-license "Category X: LicenseRef-Intel-SSL")
+  - [JSR-275 License](https://github.com/unitsofmeasurement/jsr-275/blob/0.9.3/LICENSE.txt "Category X: LicenseRef-JSR-275")
+  - Field of use restrictions:
+    - [Microsoft Limited Public License](https://www.openhub.net/licenses/mslpl "Category X: MS-LPL")
+    - [Amazon Software License (ASL)](https://aws.amazon.com/asl/ "Category X: LicenseRef-Amazon-Software-License")
+    - [Java SDK for Satori RTM license](https://github.com/satori-com/satori-rtm-sdk-java/blob/master/LICENSE "Category X: LicenseRef-Java-SDK-for-Satori-RTM")
+    - [Redis Source Available License (RSAL)](https://redislabs.com/community/licenses/ "Category X: LicenseRef-Redis-Source-Available")
+    - [Booz Allen Public License](http://boozallen.github.io/licenses/bapl "Category X: LicenseRef-Booz-Allen-Public-License")
+    - [Confluent Community License Version 1.0](https://www.confluent.io/confluent-community-license/ "Category X: LicenseRef-Confluent-Community-1.0")
+    - [Business Source License 1.1](https://spdx.org/licenses/BUSL-1.1.html "Category X: BUSL-1.1")
+    - Any license including the [Commons Clause License Condition v1.0](https://commonsclause.com "Category X: LicenseRef-Commons-Clause-1.0")
+  - Non-commercial licenses:
+    - [Creative Commons Non-Commercial](https://en.wikipedia.org/wiki/Creative_Commons_license#Non-commercial_licenses "Category X: CC-BY-NC-4.0") variants
+    - [Sun Community Source License 3.0](http://jcp.org/aboutJava/communityprocess/SCSL3.0.rtf "Category X: LicenseRef-Sun-Community-Source-3.0")
 - Places restrictions on larger works:
-    - [GNU GPL 1](https://spdx.org/licenses/GPL-1.0-only.html "Category X: GPL-1.0-only, GPL-1.0-or-later"), [GNU GPL 2](https://spdx.org/licenses/GPL-2.0-only.html "Category X: GPL-2.0-only, GPL-2.0-or-later"), [GNU GPL 3](http://www.opensource.org/licenses/gpl-license.php "Category X: GPL-3.0-only, GPL-3.0-or-later")
-        - Special exceptions to the GNU GPL (e.g. [GNU Classpath](# "Category X: GPL-2.0-only WITH Classpath-exception-2.0, GPL-2.0-or-later WITH Classpath-exception-2.0, GPL-3.0-only WITH Classpath-exception-2.0, GPL-3.0-or-later WITH Classpath-exception-2.0")) unless otherwise permitted elsewhere on this page.
-    - [GNU Affero GPL 3](http://www.opensource.org/licenses/agpl-v3.html "Category X: AGPL-3.0-only, AGPL-3.0-or-later")
-    - [GNU LGPL 2](https://spdx.org/licenses/LGPL-2.0-only.html "Category X: LGPL-2.0-only, LGPL-2.0-or-later"), [LGPL 2.1](https://spdx.org/licenses/LGPL-2.1-only.html "Category X: LGPL-2.1-only, LGPL-2.1-or-later"), [LGPL 3](http://www.opensource.org/licenses/lgpl-license.php "Category X: LGPL-3.0-only, LGPL-3.0-or-later")
-    - [QPL](https://opensource.org/licenses/QPL-1.0 "Category X: QPL-1.0")
-    - [Sleepycat License](http://www.opensource.org/licenses/sleepycat.php "Category X: Sleepycat")
-    - [Server Side Public License (SSPL) version 1](https://www.mongodb.com/licensing/server-side-public-license "Category X: SSPL-1.0")
-    - [Code Project Open License (CPOL)](http://www.codeproject.com/info/cpol10.aspx "Category X: CPOL-1.02")
+  - [GNU GPL 1](https://spdx.org/licenses/GPL-1.0-only.html "Category X: GPL-1.0-only, GPL-1.0-or-later"), [GNU GPL 2](https://spdx.org/licenses/GPL-2.0-only.html "Category X: GPL-2.0-only, GPL-2.0-or-later"), [GNU GPL 3](http://www.opensource.org/licenses/gpl-license.php "Category X: GPL-3.0-only, GPL-3.0-or-later")
+    - Special exceptions to the GNU GPL (e.g. [GNU Classpath](# "Category X: GPL-2.0-only WITH Classpath-exception-2.0, GPL-2.0-or-later WITH Classpath-exception-2.0, GPL-3.0-only WITH Classpath-exception-2.0, GPL-3.0-or-later WITH Classpath-exception-2.0")) unless otherwise permitted elsewhere on this page. <!-- markdownlint-disable-line MD042 -->
+  - [GNU Affero GPL 3](http://www.opensource.org/licenses/agpl-v3.html "Category X: AGPL-3.0-only, AGPL-3.0-or-later")
+  - [GNU LGPL 2](https://spdx.org/licenses/LGPL-2.0-only.html "Category X: LGPL-2.0-only, LGPL-2.0-or-later"), [LGPL 2.1](https://spdx.org/licenses/LGPL-2.1-only.html "Category X: LGPL-2.1-only, LGPL-2.1-or-later"), [LGPL 3](http://www.opensource.org/licenses/lgpl-license.php "Category X: LGPL-3.0-only, LGPL-3.0-or-later")
+  - [QPL](https://opensource.org/licenses/QPL-1.0 "Category X: QPL-1.0")
+  - [Sleepycat License](http://www.opensource.org/licenses/sleepycat.php "Category X: Sleepycat")
+  - [Server Side Public License (SSPL) version 1](https://www.mongodb.com/licensing/server-side-public-license "Category X: SSPL-1.0")
+  - [Code Project Open License (CPOL)](http://www.codeproject.com/info/cpol10.aspx "Category X: CPOL-1.02")
 - Other concerns:
-    - [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html "Category X: BSD-4-Clause")/[BSD-4-Clause (University of California-Specific)](https://spdx.org/licenses/BSD-4-Clause-UC.html "Category X: BSD-4-Clause-UC")
-    - [Facebook BSD+Patents license](https://code.facebook.com/pages/850928938376556 "Category X: LicenseRef-Facebook-BSD-Patents")
-    - [NPL 1.0](https://spdx.org/licenses/NPL-1.0.html "Category X: NPL-1.0")/[NPL 1.1](https://spdx.org/licenses/NPL-1.1.html "Category X: NPL-1.1")
-    - Nonsensical licenses:
-        - [The Solipsistic Eclipse Public License](# "Category X: LicenseRef-Solipsistic-Eclipse-Public-License")
-        - [The "Don't Be A Dick" Public License](https://dbad-license.org/ "Category X: LicenseRef-DBAD")
-        - [JSON License](http://www.json.org/license.html "Category X: JSON")
+  - [BSD-4-Clause](https://spdx.org/licenses/BSD-4-Clause.html "Category X: BSD-4-Clause")/[BSD-4-Clause (University of California-Specific)](https://spdx.org/licenses/BSD-4-Clause-UC.html "Category X: BSD-4-Clause-UC")
+  - [Facebook BSD+Patents license](https://code.facebook.com/pages/850928938376556 "Category X: LicenseRef-Facebook-BSD-Patents")
+  - [NPL 1.0](https://spdx.org/licenses/NPL-1.0.html "Category X: NPL-1.0")/[NPL 1.1](https://spdx.org/licenses/NPL-1.1.html "Category X: NPL-1.1")
+  - Nonsensical licenses:
+    - [The Solipsistic Eclipse Public License](# "Category X: LicenseRef-Solipsistic-Eclipse-Public-License") <!-- markdownlint-disable-line MD042 -->
+    - [The "Don't Be A Dick" Public License](https://dbad-license.org/ "Category X: LicenseRef-DBAD")
+    - [JSON License](http://www.json.org/license.html "Category X: JSON")
 
 Details of 'other concerns':
 
@@ -341,10 +342,9 @@ to obtain and install the non-included work. Optional means that the component i
 standard use of the product or for the product to achieve a desirable level of quality. The question to
 ask yourself in this situation is:
 
-* "Will the majority of users want to use my product without adding the optional components?"
+- "Will the majority of users want to use my product without adding the optional components?"
 
-
-## FAQ:
+## FAQ
 
 ### Does it matter what platform an Apache product is created to work with?  {#platform}
 
@@ -373,7 +373,6 @@ When including that work's licensing, state which license you are using and incl
 Category A to Category B to Category X. You don't need to modify the
 work itself if, for example, it mentions the various licensing options
 in the source headers.
-
 
 ### What Are Required Third-party Notices?  {#required-third-party-notices}
 

--- a/notes/api-security.md
+++ b/notes/api-security.md
@@ -17,7 +17,6 @@ To make a request to a committer protected endpoint on the API, committers must 
 
 Every JWT issued by the ATR expires in 90 minutes, uses the HS256 (HMAC-SHA256) algorithm, and makes `sub` (ASF UID), `iat` (issue time), `exp` (expires at), and `jti` (token payload) claims. JWTs are stateless, so there is no analogue stored by the ATR, except for the secret symmetric key of the server which is initialised on startup. If the ATR server is restarted, all JWTs are expired immediately.
 
-
 The JWT can be used to access protected endpoints by using it in the `Authorization` header as a bearer token, i.e. `Authorization: Bearer ${JWT_TOKEN}`. PATs and JWTs must never appear in URLs. They must be protected by the user at all times. Accidental sharing of a PAT or a JWT must be reported to ASF security.
 
 Note that PATs cannot be used to access protected endpoints. They can only be used to issue a JWT, which is then used to access protected endpoints.

--- a/notes/development.md
+++ b/notes/development.md
@@ -19,7 +19,7 @@ make serve
 
 And add the following line to your `/etc/hosts`:
 
-```
+```text
 127.0.0.1  localhost.apache.org
 ```
 

--- a/notes/plan.md
+++ b/notes/plan.md
@@ -5,6 +5,7 @@ This is a rough plan of immediate tasks. The priority of these tasks may change,
 ## UX improvements
 
 1. Improve RC workflow
+
    - [DONE] Allow upload of checksum file alongside artifacts and signatures
    - [DONE] Add a form field to choose the RC artifact type
    - [DONE] Allow extra types of artifact, such as reproducible binary and convenience binary
@@ -17,6 +18,7 @@ This is a rough plan of immediate tasks. The priority of these tasks may change,
    - Add further methods to allow the bulk addition of RC artifacts
 
 2. Enhance RC display
+
    - [DONE] Augment raw file hashes with the original filenames in the UI
    - [DONE] Add file size and upload timestamp
    - [DONE] Improve the layout of file listings
@@ -29,6 +31,7 @@ This is a rough plan of immediate tasks. The priority of these tasks may change,
    - Improve validation status indicators
 
 3. Improve key management interface
+
    - [DONE] Display which PMCs are using each key
    - [DONE] Add key expiration warnings
    - [DONE] Fix reported problem with adding keys
@@ -37,23 +40,27 @@ This is a rough plan of immediate tasks. The priority of these tasks may change,
    - Allow +1 binding voters to have their signatures added to the release
 
 4. Release status dashboard
+
    - Add progress indicators for release phases
    - Show current blockers and required actions
    - Add quick actions for release managers
 
 5. General website improvements
+
    - Add orienting style or features to improve navigability
 
 Advanced tasks, possibly deferred
-   - Implement a key revocation workflow
-   - Check RC file naming conventions
-   - Add ability to sign artifact hashes on the platform using JS
+
+- Implement a key revocation workflow
+- Check RC file naming conventions
+- Add ability to sign artifact hashes on the platform using JS
 
 ## Task scheduler
 
 We aim to work on the task scheduler in parallel with the UX improvements above. Artifact validation and the release status dashboard are dependent on tasks, which are managed by the task scheduler.
 
 1. Task runner workers
+
    - [DONE] Implement worker process with RLIMIT controls for CPU and RAM
    - [DONE] Implement safe handling for compressed asset expansion
    - [DONE] Test external tool use
@@ -68,22 +75,26 @@ We aim to work on the task scheduler in parallel with the UX improvements above.
    - Add UI to restart all waiting workers
 
 2. Orchestrating manager and resource management
+
    - [DONE] Implement process-based task isolation
    - [DONE] Create task table in sqlite database
    - [DONE] Add task queue management
    - Track and limit disk usage per task in the manager
 
 3. Improve the task UI
+
    - [DONE] Allow restarting all tasks when inactive
    - Test that tasks are deleted when a package is deleted
 
 Advanced tasks, possibly deferred
-   - Check fair scheduling across cores
-   - Add task monitoring and reporting
+
+- Check fair scheduling across cores
+- Add task monitoring and reporting
 
 ## Site improvements
 
 1. Fix bugs and improve workflow
+
    - [DONE] Add ATR commit or version number to the UI
    - [DONE] Fix and improve the package checks summary count
    - [DONE] Improve the proprietary platform patch in ASFQuart
@@ -92,30 +103,36 @@ Advanced tasks, possibly deferred
    - Decide whether to use Alembic and, if not, remove `alembic.cfg`
 
 2. Ensure that performance is optimal
+
    - [DONE] Add page load timing metrics to a log
    - [DONE] Add a basic metrics dashboard
 
 3. Increase the linting, type checking, and other QA
+
    - [DONE] Potentially add blockbuster
    - Create website UX integration tests using a browser driver
 
 Advanced tasks, possibly deferred
-   - Patch the synchronous behaviour in Jinja and submit upstream
+
+- Patch the synchronous behaviour in Jinja and submit upstream
 
 ## Basic RC validation
 
 These tasks are dependent on the task scheduler above.
 
 1. Basic artifact validation
+
    - [DONE] Implement basic archive verification
    - [DONE] Implement basic signature verification
 
 2. License compliance
+
    - [DONE] Verify LICENSE and NOTICE files exist and are placed correctly
    - [DONE] Check for Apache License headers in source files
    - [DONE] Basic RAT integration for license header validation
 
 3. SBOM integration
+
    - [DONE] Generate a basic SBOM for release artifacts
    - Store SBOMs with release metadata
    - Add SBOM management options to UI
@@ -127,17 +144,20 @@ These tasks are dependent on the task scheduler above.
 ## Advanced RC validation
 
 1. Reproducible build verification
+
    - [DONE] Accept upload of binary packages
    - Compare built artifacts with any existing provided binary artifacts
    - Give a detailed report of differences between user provided builds
 
 2. Dependency analysis
+
    - Parse and validate dependency licenses
    - Check for prohibited licenses
    - Generate dependency reports
    - Flag dependency vulnerabilities
 
 3. Distribution channel integration
+
    - Add PyPI distribution support
    - Implement Maven Central publishing
    - Add Docker Hub integration
@@ -148,6 +168,7 @@ These tasks are dependent on the task scheduler above.
 These are long term implementation requirements.
 
 1. Vote management
+
    - Automate vote thread creation
    - Track votes and calculate results
    - Generate vote summaries
@@ -155,11 +176,13 @@ These are long term implementation requirements.
    - Display vote status and timeline
 
 2. Release announcement
+
    - Template-based announcement generation with all required metadata
    - Support customisation by PMCs
    - Automate mailing list distribution
 
 3. GitHub integration
+
    - Support GHA-based release uploads
    - Add release tagging integration
    - Support automated PR creation

--- a/notes/test-user-flows.md
+++ b/notes/test-user-flows.md
@@ -8,19 +8,19 @@ To install the `atr` command, use the [instructions in the client `README.md`](h
 
 [Create a PAT](https://release-test.apache.org/tokens) using the UI, then store the value in `atr` configuration.
 
-```
+```shell
 atr set tokens.pat "$PAT_FROM_UI"
 ```
 
 You can view the configuration file to check that the value is set. **This will write secret values to stdout.**
 
-```
+```shell
 atr config file
 ```
 
 The following commands constitute roughly an entire flow, which will be reflected in the UI. We are using `tooling-test-example` as the project name. Don't forget to [create this or another project](https://release-test.apache.org/project/add/tooling), or [use an existing project](https://release-test.apache.org/committees) as applicable. Use your ASF UID `@apache.org` instead of `example`.
 
-```
+```shell
 atr release start tooling-test-example 0.1+demo
 
 atr upload tooling-test-example 0.1+demo example.txt ../example.txt
@@ -44,13 +44,13 @@ atr announce tooling-test-example 0.1+demo 00003 -m example@apache.org -s Subjec
 
 When finished with an example flow, it is recommended that you delete the version.
 
-```
+```shell
 atr dev delete tooling-test-example 0.1+demo
 ```
 
 If there is ever a problem with a JWT verification, try refreshing your JWT.
 
-```
+```shell
 atr jwt refresh | wc
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,7 +60,7 @@ Analyses release artifact path patterns from Apache distribution repositories. R
 
 Excerpt from example output:
 
-```
+```console
 --- age ---
 
   VERSIONS: 1.1.0, 1.5.0


### PR DESCRIPTION
Add basic markdownlint config file

closes #347 

Rules are from here:

https://github.com/DavidAnson/markdownlint?tab=readme-ov-file#rules--aliases

cmark generate HTML