### PR TITLE
README: Remove minor underline from workflow buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,11 @@
 *A prototype service for verifying and distributing Apache releases securely.*
 
 <a href="https://github.com/apache/tooling-trusted-releases/actions/workflows/build.yml?query=branch%3Amain">
-  <img alt="Build & Tests" src="https://github.com/apache/tooling-trusted-releases/actions/workflows/build.yml/badge.svg?branch=main" />
-</a>
+  <img alt="Build & Tests" src="https://github.com/apache/tooling-trusted-releases/actions/workflows/build.yml/badge.svg?branch=main" /></a>
 <a href="https://github.com/apache/tooling-trusted-releases/actions/workflows/analyze.yml">
-  <img alt="Analyze using pre-commit hooks" src="https://github.com/apache/tooling-trusted-releases/actions/workflows/analyze.yml/badge.svg" />
-</a>
+  <img alt="Analyze using pre-commit hooks" src="https://github.com/apache/tooling-trusted-releases/actions/workflows/analyze.yml/badge.svg" /></a>
 <a href="https://github.com/apache/tooling-trusted-releases/blob/main/LICENSE">
-  <img alt="Apache License" src="https://img.shields.io/github/license/apache/tooling-trusted-releases" />
-</a>
+  <img alt="Apache License" src="https://img.shields.io/github/license/apache/tooling-trusted-releases" /></a>
 
 ## Status
 


### PR DESCRIPTION
I tested in both Chrome and Opera the minor blue marks appear.

Just thought I would bring this up.  Please close this PR if not needed. Thanks !

## Old look

<img width="1552" height="722" alt="atr-buttons-blue-underline" src="https://github.com/user-attachments/assets/1c3cf374-a47e-4a16-8d91-c958bc37527f" />

## New look

<img width="1603" height="989" alt="Screenshot from 2025-11-30 06-42-18" src="https://github.com/user-attachments/assets/ca4f8133-2dac-4065-920d-2df4b2408e35" />

So the cleaner buttons are also seen here:

https://github.com/jbampton/tooling-trusted-releases/blob/86c88dc53e380cf6e586c361355e3936b2946d92/README.md