### PR TITLE
Pull previous SBOM results into the report and highlight new/changed vulnerabilities/licenses

### DIFF
--- a/atr/htm.py
+++ b/atr/htm.py
@@ -44,6 +44,7 @@ h1 = htpy.h1
 h2 = htpy.h2
 h3 = htpy.h3
 html = htpy.html
+i = htpy.i
 li = htpy.li
 p = htpy.p
 pre = htpy.pre
@@ -277,6 +278,10 @@ class Block:
     def ul(self) -> BlockElementCallable:
         self.__check_parent("ul", {"body", "div"})
         return BlockElementCallable(self, ul)
+
+
+def icon(name: str, classes="") -> Element:
+    return i(f".bi.bi-{name}{classes}")
 
 
 def ul_links(*items: tuple[str, str]) -> Element:

--- a/atr/models/results.py
+++ b/atr/models/results.py
@@ -128,6 +128,9 @@ class SBOMToolScore(schema.Strict):
     version_name: str = schema.description("Version name")
     revision_number: str = schema.description("Revision number")
     bom_version: int | None = schema.Field(default=None, strict=False, description="BOM Version scanned")
+    prev_bom_version: int | None = schema.Field(
+        default=None, strict=False, description="BOM Version from previous release"
+    )
     file_path: str = schema.description("Relative path to the scored SBOM file")
     warnings: list[str] = schema.description("Warnings from the SBOM tool")
     errors: list[str] = schema.description("Errors from the SBOM tool")
@@ -140,6 +143,12 @@ class SBOMToolScore(schema.Strict):
     )
     vulnerabilities: list[str] | None = schema.Field(
         default=None, strict=False, description="Vulnerabilities found in the SBOM"
+    )
+    prev_licenses: list[str] | None = schema.Field(
+        default=None, strict=False, description="Licenses from previous release"
+    )
+    prev_vulnerabilities: list[str] | None = schema.Field(
+        default=None, strict=False, description="Vulnerabilities from previous release"
     )
     atr_props: list[dict[str, str]] | None = schema.Field(
         default=None, strict=False, description="ATR properties found in the SBOM"

--- a/atr/models/schema.py
+++ b/atr/models/schema.py
@@ -25,7 +25,7 @@ Field = pydantic.Field
 
 
 class Lax(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="allow", strict=False, validate_assignment=True)
+    model_config = pydantic.ConfigDict(extra="allow", strict=False, validate_assignment=True, validate_by_name=True)
 
 
 class Strict(pydantic.BaseModel):

--- a/atr/sbom/cli.py
+++ b/atr/sbom/cli.py
@@ -31,7 +31,7 @@ from .utilities import bundle_to_ntia_patch, bundle_to_vuln_patch, patch_to_data
 
 
 def command_license(bundle: models.bundle.Bundle) -> None:
-    warnings, errors = check(bundle.bom)
+    _, warnings, errors = check(bundle.bom)
     if warnings:
         print("WARNINGS (Category B):")
         for warning in warnings:

--- a/atr/sbom/licenses.py
+++ b/atr/sbom/licenses.py
@@ -23,9 +23,11 @@ from .spdx import license_expression_atoms
 
 def check(
     bom_value: models.bom.Bom,
-) -> tuple[list[models.licenses.Issue], list[models.licenses.Issue]]:
+    include_all: bool = False,
+) -> tuple[list[models.licenses.Issue], list[models.licenses.Issue], list[models.licenses.Issue]]:
     warnings: list[models.licenses.Issue] = []
     errors: list[models.licenses.Issue] = []
+    good: list[models.licenses.Issue] = []
 
     components = bom_value.components or []
     if bom_value.metadata and bom_value.metadata.component:
@@ -99,5 +101,17 @@ def check(
                         component_type=type,
                     )
                 )
+            elif include_all:
+                good.append(
+                    models.licenses.Issue(
+                        component_name=name,
+                        component_version=version,
+                        license_expression=license_expr,
+                        category=models.licenses.Category.A,
+                        any_unknown=False,
+                        scope=scope,
+                        component_type=type,
+                    )
+                )
 
-    return warnings, errors
+    return good, warnings, errors

--- a/atr/sbom/models/base.py
+++ b/atr/sbom/models/base.py
@@ -21,7 +21,7 @@ import pydantic
 
 
 class Lax(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="allow", strict=False)
+    model_config = pydantic.ConfigDict(extra="allow", strict=False, validate_assignment=True, validate_by_name=True)
 
 
 class Strict(pydantic.BaseModel):

--- a/atr/static/css/atr.css
+++ b/atr/static/css/atr.css
@@ -545,3 +545,7 @@ td.atr-shrink {
 .atr-checks-files {
     line-height: 2.25;
 }
+
+.atr-text-strike {
+    text-decoration: line-through;
+}


### PR DESCRIPTION
- Includes previous vulns and licenses in SBOMToolScore task results
- Previous calculated using lexographic version sort
- Shows changes to each on the report
- Reorganises report get function 
- License scanner now optionally returns category A licenses in addition to B and X
- Add icon function to htm for bootstrap icons