### PR TITLE
Add GitHub Actions PR labeler for automatic labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"
+
+source:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.py"
+
+workflows:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "playwright/**"
+
+routes:
+  - changed-files:
+      - any-glob-to-any-file: "atr/{get,post,shared}/**"
+
+storage:
+  - changed-files:
+      - any-glob-to-any-file: "atr/storage/**"
+
+migrations:
+  - changed-files:
+      - any-glob-to-any-file: "migrations/**"
+
+containers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Dockerfile.alpine"
+          - "Dockerfile.ubuntu"
+          - "start-atr.sh"
+
+models:
+  - changed-files:
+      - any-glob-to-any-file: "atr/models/**"
+
+tasks:
+  - changed-files:
+      - any-glob-to-any-file: "atr/tasks/**"
+
+scripts:
+  - changed-files:
+      - any-glob-to-any-file: "scripts/**"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,18 @@
+name: Pull Request Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds a GitHub Actions labeler to automatically label pull requests
based on changed files.

Labels follow the discussion in issue #373.

Fixes #373
