### PR TITLE
Clean up SSL shutdown noise in logs

### DIFF
--- a/atr/post/upload.py
+++ b/atr/post/upload.py
@@ -113,7 +113,11 @@ async def stage(
     except ValueError:
         return _json_error("Invalid session token", 400)
 
-    files = await quart.request.files
+    try:
+        files = await quart.request.files
+    except (asyncio.CancelledError, OSError) as e:
+        log.warning(f"Connection closed during file staging: {e!s}")
+        return _json_error("Connection closed", 400)
     file = files.get("file")
     if (not file) or (not file.filename):
         return _json_error("No file provided", 400)


### PR DESCRIPTION
This PR stops the hypercorn.log from being flooded with "SSL shutdown timed out" errors and messy stack traces. These are usually just network noise caused by people disconnecting mid-upload.

# Changes I made:
- Better Error Catching: I wrapped form and file parsing in `try/except` blocks. Now, if a user disconnects, the server handles it quietly with a simple warning instead of a giant error.
- Log Filter: Added a filter to silence the specific "SSL shutdown timed out" message, which isn't an actual application bug.

fixes issue #582