### PR TITLE
Limit archive member count to prevent zip bomb attacks

### DIFF
--- a/atr/tasks/checks/targz.py
+++ b/atr/tasks/checks/targz.py
@@ -16,12 +16,12 @@
 # under the License.
 
 import asyncio
-import tarfile
 from typing import Final
 
 import atr.archives as archives
 import atr.log as log
 import atr.models.results as results
+import atr.tarzip as tarzip
 import atr.tasks.checks as checks
 
 
@@ -52,8 +52,8 @@ def root_directory(tgz_path: str) -> str:
     """Find the root directory in a tar archive and validate that it has only one root dir."""
     root = None
 
-    with tarfile.open(tgz_path, mode="r|gz") as tf:
-        for member in tf:
+    with tarzip.open_archive(tgz_path) as archive:
+        for member in archive:
             if member.name and member.name.split("/")[-1].startswith("._"):
                 # Metadata convention
                 continue

--- a/atr/util.py
+++ b/atr/util.py
@@ -50,6 +50,7 @@ import atr.ldap as ldap
 import atr.log as log
 import atr.models.sql as sql
 import atr.registry as registry
+import atr.tarzip as tarzip
 import atr.user as user
 
 T = TypeVar("T")
@@ -95,26 +96,16 @@ async def archive_listing(file_path: pathlib.Path) -> list[str] | None:
         return None
 
     with contextlib.suppress(Exception):
-        if file_path.name.endswith((".tar.gz", ".tgz")):
+        if file_path.name.endswith((".tar.gz", ".tgz", ".zip")):
 
-            def _read_tar() -> list[str] | None:
-                with contextlib.suppress(tarfile.ReadError, EOFError, ValueError, OSError):
-                    with tarfile.open(file_path, mode="r:*") as tf:
+            def _read_archive() -> list[str] | None:
+                with contextlib.suppress(tarfile.ReadError, zipfile.BadZipFile, EOFError, ValueError, OSError):
+                    with tarzip.open_archive(str(file_path)) as archive:
                         # TODO: Skip metadata files
-                        return sorted(tf.getnames())
+                        return sorted(member.name for member in archive)
                 return None
 
-            return await asyncio.to_thread(_read_tar)
-
-        elif file_path.name.endswith(".zip"):
-
-            def _read_zip() -> list[str] | None:
-                with contextlib.suppress(zipfile.BadZipFile, EOFError, ValueError, OSError):
-                    with zipfile.ZipFile(file_path, "r") as zf:
-                        return sorted(zf.namelist())
-                return None
-
-            return await asyncio.to_thread(_read_zip)
+            return await asyncio.to_thread(_read_archive)
 
     return None
 


### PR DESCRIPTION
## Limit archive member count to prevent zip bomb attacks

Closes #604

### Summary

This PR adds a configurable limit on the number of members that can be extracted from an archive, preventing denial-of-service attacks that use archives with millions of small files to exhaust filesystem metadata (inodes), memory, or worker processes.

### Changes

**`atr/tarzip.py`**
- Added `MAX_ARCHIVE_MEMBERS` constant (default: 100,000)
- Added `ArchiveMemberLimitExceeded` exception
- Updated `ArchiveContext.__iter__()` to count members and raise if limit exceeded
- Added `extract_member()` method for cleaner directory extraction
- Made limit configurable via `open_archive(path, max_members=N)`

**`atr/archives.py`**
- Unified tar iteration to go through `ArchiveContext` (previously bypassed it by iterating directly on `TarFile`)
- Updated function signatures to use `tarzip.TarMember` instead of `tarfile.TarInfo`

**`atr/util.py`**
- Updated `archive_listing()` to use `tarzip.open_archive()` instead of direct `tarfile`/`zipfile` access

**`atr/tasks/checks/targz.py`**
- Updated `root_directory()` to use `tarzip.open_archive()`

**`atr/tasks/checks/zipformat.py`**
- Updated `_integrity_check_core_logic()` and `_structure_check_core_logic()` to use `tarzip.open_archive()`

### Result

All archive iteration now flows through a single chokepoint (`ArchiveContext.__iter__`), which enforces the member count limit for both tar and zip files.

### ASVS Compliance

- **5.2.1** - File processing cannot cause denial of service

* [x] I have read and followed **CONTRIBUTING.md**
* [x] I have read **DEVELOPMENT.md**
* [x] I have run the required tests and checks locally
* [x] All required checks are currently passing
* [x] This branch is **rebased on the current `main` branch**

---

## Rebase confirmation details (optional but encouraged)
```
$ git fetch upstream 
remote: Enumerating objects: 39, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 39 (delta 21), reused 21 (delta 12), pack-reused 0 (from 0)
Unpacking objects: 100% (39/39), 14.79 KiB | 541.00 KiB/s, done.
From github.com:apache/tooling-trusted-releases
 * [new branch]        dependabot/github_actions/actions/cache-5.0.2       -> upstream/dependabot/github_actions/actions/cache-5.0.2
 * [new branch]        dependabot/github_actions/actions/checkout-6.0.2    -> upstream/dependabot/github_actions/actions/checkout-6.0.2
 * [new branch]        dependabot/github_actions/biomejs/setup-biome-2.7.0 -> upstream/dependabot/github_actions/biomejs/setup-biome-2.7.0
 * [new branch]        jwtoken_multiple_sources                            -> upstream/jwtoken_multiple_sources
 * [new branch]        rate_limiting                                       -> upstream/rate_limiting
$ git rebase upstream/main
Current branch archive-member-count-604 is up to date.
```
