### PR TITLE
Check templates linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,3 +195,10 @@ repos:
       language: system
       pass_filenames: false
       files: ^atr/models/.*\.py$
+
+    - id: template-usage-linter
+      name: check template usage
+      description: Ensure that all templates are used and available w/o duplicates
+      entry: uv run --frozen python scripts/check_templates.py atr
+      language: system
+      pass_filenames: false

--- a/scripts/check_templates.py
+++ b/scripts/check_templates.py
@@ -1,10 +1,27 @@
 #!/usr/bin/env python3
-import ast
-import sys
-from pathlib import Path
-from collections import defaultdict
-import re
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import argparse
+import ast
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
 
 TEMPLATE_SUFFIXES = {".html", ".htm", ".j2", ".jinja"}
 JINJA_REF_RE = re.compile(
@@ -37,7 +54,7 @@ def detect_cycles(graph):
 
     def visit(node, stack):
         if node in visiting:
-            cycle = stack[stack.index(node):] + [node]
+            cycle = [*stack[stack.index(node) :], node]
             cycles.append(cycle)
             return
         if node in visited:
@@ -45,7 +62,7 @@ def detect_cycles(graph):
 
         visiting.add(node)
         for nxt in graph.get(node, ()):
-            visit(nxt, stack + [nxt])
+            visit(nxt, [*stack, nxt])
         visiting.remove(node)
         visited.add(node)
 
@@ -102,7 +119,7 @@ def find_templates_in_code(source_root: Path):
 
     used.add("blank.html")
     origins["blank.html"].append(("atr/template.py", 42))
-        
+
     return used, origins
 
 
@@ -149,7 +166,23 @@ def reverse_refs(refs):
     return rev
 
 
-def main():
+def print_map(reachable, origins, rev_refs, refs):
+    print("\n== Template usage map ==")
+    for name in sorted(reachable):
+        print(f"\n{name}")
+
+        if name in origins:
+            for file, line in origins[name]:
+                print(f"  rendered from {file}:{line}")
+
+        for parent in sorted(rev_refs.get(name, [])):
+            print(f"  included by {parent}")
+
+        for child in sorted(refs.get(name, [])):
+            print(f"  includes {child}")
+
+
+def main():  # noqa: C901
     parser = argparse.ArgumentParser()
     parser.add_argument("source_root", help="Source tree root")
     parser.add_argument(
@@ -168,25 +201,13 @@ def main():
     rev_refs = reverse_refs(refs)
 
     missing = used - present
-    
+
     duplicates = {k: v for k, v in locations.items() if len(v) > 1}
     unreachable = present - reachable
     cycles = detect_cycles(refs)
 
     if args.usage_map:
-        print("\n== Template usage map ==")
-        for name in sorted(reachable):
-            print(f"\n{name}")
-
-            if name in origins:
-                for file, line in origins[name]:
-                    print(f"  rendered from {file}:{line}")
-
-            for parent in sorted(rev_refs.get(name, [])):
-                print(f"  included by {parent}")
-
-            for child in sorted(refs.get(name, [])):
-                print(f"  includes {child}")
+        print_map(reachable, origins, rev_refs, refs)
 
     errors = False
 
@@ -228,6 +249,7 @@ def main():
             print("  " + " → ".join(cycle))
 
     sys.exit(1 if errors else 0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Pull request summary <!-- markdownlint-disable-line MD041 -->

**Meaningful subject (required):**

Template usage linter closes #327 

**Description:**

Adds a linter which checks for missing and duplicate jinja2 templates.

```
python3 scripts/check_templates.py atr --usage-map
```

```

== Template usage map ==

about.html
  rendered from atr/get/root.py:64
  includes base.html

all-releases.html
  rendered from atr/admin/__init__.py:107
  includes base.html

base-admin.html
  included by browse-as.html
  included by data-browser.html
  included by ldap-lookup.html
  included by performance.html
  included by toggle-admin-view.html
  included by update-keys.html
  included by update-projects.html
  includes base.html

base.html
  included by about.html
  included by all-releases.html
  included by base-admin.html
  included by blank.html
  included by check-selected.html
  included by committee-directory.html
  included by committee-view.html
  included by delete-committee-keys.html
  included by delete-release.html
  included by download-all.html
  included by draft-tools.html
  included by error.html
  included by index-committer.html
  included by index-public.html
  included by notfound.html
  included by project-select.html
  included by projects.html
  included by release-select.html
  included by releases-finished.html
  included by releases.html
  included by report-selected-path.html
  included by resolve-tabulated.html
  included by tutorial.html
  included by validation.html
  includes flash.html
  includes footer.html
  includes forms.html
  includes topnav.html

blank.html
  rendered from atr/template.py:42
  includes base.html

browse-as.html
  rendered from atr/admin/__init__.py:117
  includes base-admin.html

check-selected-candidate-forms.html
  included by check-selected.html
  includes check-selected-vote-email.html

check-selected-path-table.html
  included by check-selected.html

check-selected-release-info.html
  included by check-selected.html

check-selected-vote-email.html
  included by check-selected-candidate-forms.html

check-selected.html
  rendered from atr/shared/web.py:141
  includes base.html
  includes check-selected-candidate-forms.html
  includes check-selected-path-table.html
  includes check-selected-release-info.html

committee-directory.html
  rendered from atr/get/committees.py:38
  includes base.html

committee-view.html
  rendered from atr/get/committees.py:59
  includes base.html

data-browser.html
  rendered from atr/admin/__init__.py:972
  includes base-admin.html

delete-committee-keys.html
  rendered from atr/admin/__init__.py:262
  includes base.html
  includes forms.html

delete-release.html
  rendered from atr/admin/__init__.py:349
  includes base.html

download-all.html
  rendered from atr/get/download.py:52
  includes base.html
  includes user-ssh-keys.html

draft-tools.html
  rendered from atr/get/draft.py:81
  includes base.html

error.html
  rendered from atr/server.py:830
  rendered from atr/server.py:836
  rendered from atr/server.py:848
  rendered from atr/server.py:857
  rendered from atr/server.py:880
  includes base.html

flash.html
  included by base.html

footer.html
  included by base.html

forms.html
  included by base.html
  included by delete-committee-keys.html

index-committer.html
  rendered from atr/get/root.py:130
  includes base.html

index-public.html
  rendered from atr/get/root.py:74
  rendered from atr/get/root.py:139
  includes base.html

ldap-lookup.html
  rendered from atr/admin/__init__.py:511
  rendered from atr/admin/__init__.py:551
  includes base-admin.html

notfound.html
  rendered from atr/server.py:865
  includes base.html

performance.html
  rendered from atr/admin/__init__.py:610
  rendered from atr/admin/__init__.py:670
  includes base-admin.html

project-select.html
  rendered from atr/get/projects.py:133
  includes base.html

projects.html
  rendered from atr/get/projects.py:107
  includes base.html

release-select.html
  rendered from atr/get/release.py:90
  includes base.html

releases-finished.html
  rendered from atr/get/release.py:50
  includes base.html

releases.html
  rendered from atr/get/release.py:73
  includes base.html

report-selected-path.html
  rendered from atr/get/report.py:75
  includes base.html

resolve-tabulated.html
  rendered from atr/post/resolve.py:144
  includes base.html

toggle-admin-view.html
  rendered from atr/admin/__init__.py:872
  includes base-admin.html

topnav.html
  included by base.html

tutorial.html
  rendered from atr/get/root.py:158
  includes base.html

update-keys.html
  rendered from atr/admin/__init__.py:483
  includes base-admin.html

update-projects.html
  rendered from atr/admin/__init__.py:682
  includes base-admin.html

user-ssh-keys.html
  included by download-all.html

validation.html
  rendered from atr/admin/__init__.py:901
  includes base.html
```
---

## Required acknowledgements

Please replace each `[ ]` with `[x]` to confirm.
PRs missing confirmations may be closed or converted to Draft.

* [x] I have read and followed **CONTRIBUTING.md**
* [x] I have read **DEVELOPMENT.md**
* [x] I have run the required tests and checks locally
* [x] All required checks are currently passing
* [x] This branch is **rebased on the current `main` branch**

---

## Draft requirement

If **any** of the following are true:

* Tests or checks are failing
* Work is incomplete
* Rebase on `main` is pending

**This PR MUST be opened or converted to a Draft**:

Convert to a ready PR only after all acknowledgements above can be confirmed.

---

## Rebase confirmation details (optional but encouraged)

<!--
If helpful, note how the rebase was done:
  git fetch origin
  git rebase origin/main
-->

---

## Additional notes

<!--
Anything reviewers should know:
- Design decisions
- Follow-up work
- Compatibility concerns
-->
