### PR TITLE
#677 - Add explicit ciphers, kex and mac algorithms.

### DIFF
--- a/atr/ssh.py
+++ b/atr/ssh.py
@@ -43,6 +43,36 @@ import atr.util as util
 
 _CONFIG: Final = config.get()
 
+_APPROVED_CIPHERS: Final[list[str]] = [
+    "chacha20-poly1305@openssh.com",
+    "aes256-gcm@openssh.com",
+    "aes128-gcm@openssh.com",
+    "aes256-ctr",
+    "aes192-ctr",
+    "aes128-ctr",
+]
+
+_APPROVED_KEX: Final[list[str]] = [
+    "rsa2048-sha256",
+    "curve25519-sha256",
+    "ecdh-sha2-nistp256",
+    "diffie-hellman-group16-sha512",
+]
+
+_APPROVED_MACS: Final[list[str]] = [
+    "hmac-sha2-256-etm@openssh.com",
+    "hmac-sha2-512-etm@openssh.com",
+    "hmac-sha1-etm@openssh.com",
+    "hmac-sha2-256",
+    "hmac-sha2-512",
+    "hmac-sha1",
+    "hmac-sha256-2@ssh.com",
+    "hmac-sha224@ssh.com",
+    "hmac-sha256@ssh.com",
+    "hmac-sha384@ssh.com",
+    "hmac-sha512@ssh.com",
+]
+
 
 class RsyncArgsError(Exception):
     """Exception raised when the rsync arguments are invalid."""
@@ -178,6 +208,9 @@ async def server_start() -> asyncssh.SSHAcceptor:
         host=_CONFIG.SSH_HOST,
         port=_CONFIG.SSH_PORT,
         encoding=None,
+        encryption_algs=_APPROVED_CIPHERS,
+        kex_algs=_APPROVED_KEX,
+        mac_algs=_APPROVED_MACS,
     )
 
     log.info(f"SSH server started on {_CONFIG.SSH_HOST}:{_CONFIG.SSH_PORT}")


### PR DESCRIPTION
I've created a PR for this one as I wanted to validate the choices. I tried to follow the defaults (which are slightly more broad than the original suggestion in #677) because that way we maintain the same compatibility we have today, however for the key exchange algorithms, the `asyncssh` module checks to see which capabilities are available and changes some of those defaults dynamically. We could do that checking ourselves but that feels unnecessary to me unless we specifically want to allow some of those options - hence please let me know what if any you'd like to add or remove from these lists! 