### PR TITLE
Adding comment for SSH workflow key

### DIFF
--- a/atr/ssh.py
+++ b/atr/ssh.py
@@ -158,6 +158,7 @@ class SSHServer(asyncssh.SSHServer):
             log.set_asf_uid(self._github_asf_uid)
 
             now = int(time.time())
+            # audit_guidance this application is not concerned with checking for a not_before flag on the workflow_key
             if workflow_key.expires < now:
                 log.failed_authentication("public_key_expired")
                 return False


### PR DESCRIPTION
Added in-line comment not to worry about a not_before flag for workflow_key

Fixes #674 

```
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch ssh-comment-674 is up to date.
```