### PR TITLE
Adding comment about sending mail to other committees

### DIFF
--- a/atr/tasks/message.py
+++ b/atr/tasks/message.py
@@ -56,6 +56,7 @@ async def send(args: Send) -> results.Results | None:
 
     recipient_domain = args.email_recipient.split("@")[-1]
     sending_to_self = recipient_domain == f"{sender_asf_uid}@apache.org"
+    # audit_guidance this application intentionally allows users to send messages to committees they are not a part of
     sending_to_committee = recipient_domain.endswith(".apache.org")
     if not (sending_to_self or sending_to_committee):
         raise SendError(f"You are not permitted to send emails to {args.email_recipient}")


### PR DESCRIPTION
Adding comment

Fixes #670 

```
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch message-sending-comment-670 is up to date.
```