### PR TITLE
Adding comment about public download of release files

### DIFF
--- a/atr/get/download.py
+++ b/atr/get/download.py
@@ -51,6 +51,7 @@ async def all_selected(
     URL: /download/all/<project_name>/<version_name>
     Display download commands for a release.
     """
+    # audit_guidance this application intentionally allows release files to be downloaded without authentication
     import atr.get.root as root
 
     async with db.session() as data:


### PR DESCRIPTION
Added coment

Fixes #665 

```
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main 
Current branch public-download-comment-665 is up to date.
```