### PR TITLE
Adding docs for auth bypass

### DIFF
--- a/atr/docs/authorization-security.md
+++ b/atr/docs/authorization-security.md
@@ -203,7 +203,14 @@ The cache is per-user and in-memory. It does not persist across server restarts.
 
 ### Test mode
 
-When `ALLOW_TESTS` is enabled in the configuration, a special "test" user and "test" committee are available. All authenticated users are automatically added to the test committee for testing purposes. This should never be enabled in production.
+When `ALLOW_TESTS` is enabled in the configuration, a special "test" user and "test" committee are available. **This should never be enabled in production.** The security implications are significant:
+
+1. All authenticated users (not just the test user) are granted membership in the "test" committee and project [`principal`](/ref/atr/principal.py).
+2. Authorization checks in the storage layer are completely skipped for the test committee [`release`](/ref/atr/storage/writers/release.py).
+3. Rate limiting is disabled [`server`](/ref/atr/server.py).
+4. A hardcoded "test" user bypasses LDAP verification.
+
+If `ALLOW_TESTS` is accidentally left enabled in production, every authenticated user gains unauthorized access to the test committee and its resources. This flag is intended for use only in development and test environments where `DEBUG_MODE` is also set.
 
 ## Implementation references
 

--- a/atr/docs/storage-interface.md
+++ b/atr/docs/storage-interface.md
@@ -26,6 +26,8 @@ The storage interface recognizes several permission levels: general public (unau
 
 The storage interface does not make it impossible to bypass authorization, because you can always import `db` directly and write to the database. But it makes bypassing authorization an explicit choice that requires deliberate action, and it makes the safer path the easier path. This is a pragmatic approach to security: we cannot prevent all mistakes, but we can make it harder to make them accidentally.
 
+**Note:** When `ALLOW_TESTS` is enabled, authorization checks in the storage layer are completely skipped for the test committee [`release`](/ref/atr/storage/writers/release.py). This is an intentional exception for development and test environments only. See [Authorization security](authorization-security#test-mode) for the full security implications of this flag.
+
 ## How do we read from storage?
 
 Reading from storage is a work in progress. There are some existing methods, but most of the functionality is currently in `db` or `db.interaction`, and much work is required to migrate this to the storage interface. We have given this less priority because reads are generally safe, with the exception of a few components such as user tokens, which should be given greater migration priority.


### PR DESCRIPTION
Added docs about ALLOW_TESTS and DEBUG_MODE

Fixes #659 

```
$ git fetch upstream main
remote: Enumerating objects: 32, done.
remote: Counting objects: 100% (32/32), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 21 (delta 16), reused 11 (delta 10), pack-reused 0 (from 0)
Unpacking objects: 100% (21/21), 4.87 KiB | 712.00 KiB/s, done.
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
   5fb88cfc..2d01198f  main       -> upstream/main
$ git rebase upstream/main
Successfully rebased and updated refs/heads/document-auth-bypass-659.
```