### PR TITLE
Adding relpath to docs

### DIFF
--- a/atr/docs/input-validation.md
+++ b/atr/docs/input-validation.md
@@ -274,6 +274,10 @@ Path traversal is prevented by:
 * Validating that paths remain within expected directories
 * Rejecting file names containing path separators
 
+For form fields that accept file or directory paths, always use `form.RelPath` (or `form.RelPathList` for multiple paths). These types automatically call [`to_relpath()`](/ref/atr/form.py:to_relpath), which rejects path traversal sequences, absolute paths, and empty values at the Pydantic validation layer. This is the preferred approach because it prevents path traversal before the handler code runs.
+
+For cases outside of form validation (e.g., URL route parameters), use [`form.to_relpath()`](/ref/atr/form.py:to_relpath) directly, or validate manually:
+
 ```python
 import pathlib
 

--- a/atr/docs/user-interface.md
+++ b/atr/docs/user-interface.md
@@ -83,6 +83,8 @@ Fields use Pydantic type annotations to define their data type:
 * `form.StrList` - multiple checkboxes that collect strings
 * `form.File` - single file upload
 * `form.FileList` - multiple file upload
+* `form.RelPath` - validated relative file path (rejects path traversal such as `..` and absolute paths via `to_relpath()`)
+* `form.RelPathList` - list of validated relative file paths
 * `form.Enum[EnumType]` - dropdown select from enum values
 * `form.Set[EnumType]` - multiple checkboxes from enum values
 


### PR DESCRIPTION
Added docs about RelPath and RelPathList

Fixes #721 

```
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch relpath-docs-721 is up to date.
```