### PR TITLE
Added comment about versioning

### DIFF
--- a/atr/version.py
+++ b/atr/version.py
@@ -17,5 +17,6 @@
 
 from typing import Final
 
+# audit_guidance atr/version.py is created via make generate-version using atr/metadata.py
 ATR_VERSION: Final[str] = "?"
 ATR_COMMIT: Final[str] = "?"


### PR DESCRIPTION
Added comment about how versions are populated

Fixes #710 

```
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch version-comment-710 is up to date.
```