### PR TITLE
Add support for pyproject.toml and Docker in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
       day: "monday"
     cooldown:
       default-days: 7
-  - package-ecosystem: "poetry"
-    directory: "/"             # location of pyproject.toml
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
closes: #706 