### PR TITLE
Adding a pydantic json schema for output

### DIFF
--- a/atr/models/safe.py
+++ b/atr/models/safe.py
@@ -78,6 +78,10 @@ class SafeType:
             serialization=core_schema.to_string_ser_schema(),
         )
 
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _core_schema: Any, _handler: Any) -> dict[str, Any]:
+        return {"type": "string"}
+
 
 class Alphanumeric(SafeType):
     @classmethod


### PR DESCRIPTION
# Fix OpenAPI schema generation crash for SafeType custom types

Fixes #883 

## Problem

Hitting `GET /api/openapi.json` (or loading `/api/docs`) crashes the server with:

```
ValueError: invalid literal for int() with base 10: 'invalid-for-json-schema'
```

## Root Cause

`SafeType` (the base class for `ProjectName`, `VersionName`, `RevisionNumber`, etc.) defines `__get_pydantic_core_schema__` using `no_info_plain_validator_function`, which tells pydantic v2 how to validate these types at runtime. However, it does **not** define `__get_pydantic_json_schema__`, so pydantic has no way to represent these types when generating a JSON Schema.

When pydantic can't infer a JSON Schema from an opaque validator function, it emits the placeholder string `'invalid-for-json-schema'` into the schema output. When quart_schema serves the OpenAPI spec, this placeholder ends up as the second element of a response tuple (`(<Response>, 'invalid-for-json-schema')`), which Quart interprets as a status code and calls `int('invalid-for-json-schema')` — hence the `ValueError`.

## Fix

Add `__get_pydantic_json_schema__` to `SafeType`, returning `{"type": "string"}`. All `SafeType` subclasses are validated string wrappers, so this is the correct JSON Schema representation. The method is inherited by `ProjectName`, `VersionName`, `RevisionNumber`, and any future subclasses automatically.

Pydantic v2 recognizes two dunder methods on custom types:

- **`__get_pydantic_core_schema__`** — controls runtime validation and serialization (already present)
- **`__get_pydantic_json_schema__`** — controls JSON Schema generation for OpenAPI specs (added by this PR)

## Changed files

- `atr/models/safe.py` — added `__get_pydantic_json_schema__` classmethod to `SafeType`

## Testing

1. Reproduced the bug locally
2. Confirmed the fix locally
3. Ran `make check` and passed

## Rebase

```bash
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch openapi-viewer-500-883 is up to date.
```