### PR TITLE
#1003 - add rate limiting to SSH connections

### DIFF
--- a/atr/server.py
+++ b/atr/server.py
@@ -323,6 +323,9 @@ def _app_setup_lifecycle(app: base.QuartApp, app_config: type[config.AppConfig])
         ssh_server = await ssh.server_start()
         app.extensions["ssh_server"] = ssh_server
 
+        ssh_rate_limit_task = asyncio.create_task(ssh.rate_limit_cleanup_loop())
+        app.extensions["ssh_rate_limit_task"] = ssh_rate_limit_task
+
     @app.after_serving
     async def shutdown() -> None:
         """Clean up services after the app stops serving requests."""
@@ -337,6 +340,11 @@ def _app_setup_lifecycle(app: base.QuartApp, app_config: type[config.AppConfig])
                 await scheduler_task
             except asyncio.CancelledError:
                 ...
+
+        if ssh_cleanup_task := app.extensions.get("ssh_rate_limit_task"):
+            ssh_cleanup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ssh_cleanup_task
 
         ssh_server = app.extensions.get("ssh_server")
         if ssh_server:

--- a/atr/ssh.py
+++ b/atr/ssh.py
@@ -19,6 +19,7 @@
 
 import asyncio
 import asyncio.subprocess
+import collections
 import datetime
 import glob
 import os
@@ -63,6 +64,15 @@ _PATH_ALPHANUM: Final = frozenset(string.ascii_letters + string.digits + "-")
 # We also allow + which is in common use
 _PATH_VERSION_CHARS: Final = _PATH_ALPHANUM | frozenset(".-+")
 
+_RATE_LIMIT_IP: Final = 100
+_RATE_LIMIT_USER: Final = 10
+_RATE_WINDOW: Final = 60.0
+
+# Keyed by IP address; catches all connections including failed auth
+global_ip_rate_buckets: dict[str, collections.deque[float]] = {}
+# Keyed by ASF UID; only incremented on successful authentication
+global_user_rate_buckets: dict[str, collections.deque[float]] = {}
+
 
 class RsyncArgsError(Exception):
     """Exception raised when the rsync arguments are invalid."""
@@ -75,12 +85,15 @@ class SSHServer(asyncssh.SSHServer):
 
     def connection_made(self, conn: asyncssh.SSHServerConnection) -> None:
         """Called when a connection is established."""
-        # Store connection for use in begin_auth
         self._conn = conn
         self._github_asf_uid: str | None = None
         self._github_payload: github.TrustedPublisherPayload | None = None
         peer_addr = conn.get_extra_info("peername")[0]
         log.info(f"SSH connection received from {peer_addr}")
+        if not _rate_limit_check(global_ip_rate_buckets, peer_addr, _RATE_LIMIT_IP):
+            log.warning(f"IP rate limit exceeded for {peer_addr}")
+            conn.disconnect(asyncssh.DISC_TOO_MANY_CONNECTIONS, "Rate limit exceeded")
+            return
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Called when a connection is lost or closed."""
@@ -136,11 +149,16 @@ class SSHServer(asyncssh.SSHServer):
 
     def auth_completed(self) -> None:
         username = self._conn.get_extra_info("username")
-        type = "ssh"
+        auth_type = "ssh"
         if username == "github":
-            type = "githubssh"
+            auth_type = "githubssh"
             username = self._github_asf_uid
-        log.auth_success(type, username)
+        if username and not _rate_limit_check(global_user_rate_buckets, username, _RATE_LIMIT_USER):
+            log.warning(f"User rate limit exceeded for {username}")
+            log.auth_failure(auth_type, "rate_limit_exceeded", username)
+            self._conn.disconnect(asyncssh.DISC_TOO_MANY_CONNECTIONS, "Rate limit exceeded")
+            return
+        log.auth_success(auth_type, username)
 
     def public_key_auth_supported(self) -> bool:
         """Indicate whether public key authentication is supported."""
@@ -192,6 +210,20 @@ class SSHServer(asyncssh.SSHServer):
         if username != "github":
             return None
         return self._github_payload
+
+
+async def rate_limit_cleanup_loop() -> None:
+    """Periodically remove stale entries from the rate limit buckets."""
+    while True:
+        await asyncio.sleep(_RATE_WINDOW)
+        now = time.monotonic()
+        for bucket in (global_ip_rate_buckets, global_user_rate_buckets):
+            stale_keys = [key for key, window in bucket.items() if not window or (now - window[-1]) > _RATE_WINDOW]
+            if len(stale_keys) == len(bucket):
+                bucket.clear()
+            else:
+                for key in stale_keys:
+                    del bucket[key]
 
 
 async def server_start() -> asyncssh.SSHAcceptor:
@@ -249,6 +281,22 @@ def _output_stderr(process: asyncssh.SSHServerProcess, message: str) -> None:
         log.warning("Failed to write error to client stderr: broken pipe")
     except Exception as e:
         log.exception(f"Error writing to client stderr: {e}")
+
+
+def _rate_limit_check(bucket: dict[str, collections.deque[float]], key: str, limit: int) -> bool:
+    """Return True if key is within the rate limit, False if exceeded. Mutates bucket."""
+    now = time.monotonic()
+    window = bucket.get(key)
+    if window is not None:
+        while window and (now - window[0]) > _RATE_WINDOW:
+            window.popleft()
+    if window and len(window) >= limit:
+        return False
+    if window is None:
+        window = collections.deque()
+        bucket[key] = window
+    window.append(now)
+    return True
 
 
 async def _step_01_handle_client(process: asyncssh.SSHServerProcess, server: SSHServer) -> None:

--- a/atr/ssh.py
+++ b/atr/ssh.py
@@ -202,7 +202,7 @@ async def server_start() -> asyncssh.SSHAcceptor:
     # Generate temporary host key if it doesn't exist
     key_path = os.path.join(_CONFIG.STATE_DIR, "secrets", "generated", "ssh_host_key")
     if not await aiofiles.os.path.exists(key_path):
-        private_key = asyncssh.generate_private_key("ssh-rsa")
+        private_key = asyncssh.generate_private_key("ssh-ed25519")
         private_key.write_private_key(key_path)
         log.info(f"Generated SSH host key at {key_path}")
         permissions = stat.S_IMODE(os.stat(key_path).st_mode)

--- a/atr/tasks/checks/compare.py
+++ b/atr/tasks/checks/compare.py
@@ -187,7 +187,24 @@ async def _checkout_github_source(
     repo_url = f"https://github.com/{payload.repository}.git"
     started_ns = time.perf_counter_ns()
     try:
-        await asyncio.to_thread(_clone_repo, repo_url, payload.sha, checkout_dir)
+        await asyncio.wait_for(asyncio.to_thread(_clone_repo, repo_url, payload.sha, checkout_dir), timeout=360)
+    except TimeoutError:
+        elapsed_ms = (time.perf_counter_ns() - started_ns) / 1_000_000.0
+        log.exception(
+            "Timeout cloning GitHub repo for compare.source_trees",
+            repo_url=repo_url,
+            sha=payload.sha,
+            checkout_dir=str(checkout_dir),
+            clone_ms=elapsed_ms,
+            git_author_name=os.environ.get("GIT_AUTHOR_NAME"),
+            git_author_email=os.environ.get("GIT_AUTHOR_EMAIL"),
+            git_committer_name=os.environ.get("GIT_COMMITTER_NAME"),
+            git_committer_email=os.environ.get("GIT_COMMITTER_EMAIL"),
+            user=os.environ.get("USER"),
+            logname=os.environ.get("LOGNAME"),
+            email=os.environ.get("EMAIL"),
+        )
+        return None
     except Exception:
         elapsed_ms = (time.perf_counter_ns() - started_ns) / 1_000_000.0
         log.exception(

--- a/tests/unit/test_ssh_rate_limiting.py
+++ b/tests/unit/test_ssh_rate_limiting.py
@@ -1,0 +1,174 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for SSH rate limiting."""
+
+import unittest.mock as mock
+from typing import TYPE_CHECKING
+
+import asyncssh
+import pytest
+
+import atr.ssh as ssh
+
+if TYPE_CHECKING:
+    import collections
+
+    from pytest import MonkeyPatch
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_buckets():
+    """Clear global rate limit buckets before each test to prevent state leakage."""
+    ssh.global_ip_rate_buckets.clear()
+    ssh.global_user_rate_buckets.clear()
+    yield
+    ssh.global_ip_rate_buckets.clear()
+    ssh.global_user_rate_buckets.clear()
+
+
+# _rate_limit_check
+
+
+def test_rate_limit_check_allows_within_limit():
+    bucket: dict[str, collections.deque[float]] = {}
+    for _ in range(ssh._RATE_LIMIT_USER):
+        assert ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER) is True
+
+
+def test_rate_limit_check_blocks_when_limit_reached():
+    bucket: dict[str, collections.deque[float]] = {}
+    for _ in range(ssh._RATE_LIMIT_USER):
+        ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER)
+    assert ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER) is False
+
+
+def test_rate_limit_check_allows_after_window_expires(monkeypatch: "MonkeyPatch"):
+    current_time = [1000.0]
+    monkeypatch.setattr("atr.ssh.time.monotonic", lambda: current_time[0])
+    bucket: dict[str, collections.deque[float]] = {}
+    for _ in range(ssh._RATE_LIMIT_USER):
+        ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER)
+    assert ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER) is False
+
+    current_time[0] = 1000.0 + ssh._RATE_WINDOW + 1.0
+    assert ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER) is True
+
+
+def test_rate_limit_check_keys_are_independent():
+    bucket: dict[str, collections.deque[float]] = {}
+    for _ in range(ssh._RATE_LIMIT_USER):
+        ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER)
+    assert ssh._rate_limit_check(bucket, "alice", ssh._RATE_LIMIT_USER) is False
+    assert ssh._rate_limit_check(bucket, "bob", ssh._RATE_LIMIT_USER) is True
+
+
+# connection_made — IP rate limit
+
+
+def test_connection_made_allows_within_ip_limit():
+    server = _make_server()
+    conn = _make_conn_with_ip("1.2.3.4")
+    server.connection_made(conn)
+    conn.disconnect.assert_not_called()
+
+
+def test_connection_made_blocks_when_ip_limit_exceeded():
+    for _ in range(ssh._RATE_LIMIT_IP):
+        server = _make_server()
+        server.connection_made(_make_conn_with_ip("1.2.3.4"))
+    server = _make_server()
+    conn = _make_conn_with_ip("1.2.3.4")
+    server.connection_made(conn)
+    conn.disconnect.assert_called_once_with(asyncssh.DISC_TOO_MANY_CONNECTIONS, "Rate limit exceeded")
+
+
+def test_connection_made_different_ips_are_independent():
+    for _ in range(ssh._RATE_LIMIT_IP):
+        server = _make_server()
+        server.connection_made(_make_conn_with_ip("1.2.3.4"))
+    server = _make_server()
+    conn = _make_conn_with_ip("5.6.7.8")
+    server.connection_made(conn)
+    conn.disconnect.assert_not_called()
+
+
+# auth_completed — user rate limit
+
+
+def test_auth_completed_allows_within_user_limit():
+    server = _make_server()
+    server._conn = _make_conn_with_username("alice")
+    server.auth_completed()
+    server._conn.disconnect.assert_not_called()
+
+
+def test_auth_completed_blocks_when_user_limit_exceeded():
+    for _ in range(ssh._RATE_LIMIT_USER):
+        server = _make_server()
+        server._conn = _make_conn_with_username("alice")
+        server.auth_completed()
+    server = _make_server()
+    server._conn = _make_conn_with_username("alice")
+    server.auth_completed()
+    server._conn.disconnect.assert_called_once_with(asyncssh.DISC_TOO_MANY_CONNECTIONS, "Rate limit exceeded")
+
+
+def test_auth_completed_github_uses_asf_uid_for_rate_limit():
+    for _ in range(ssh._RATE_LIMIT_USER):
+        server = _make_server()
+        server._conn = _make_conn_with_username("github")
+        server._github_asf_uid = "alice"
+        server.auth_completed()
+    server = _make_server()
+    server._conn = _make_conn_with_username("github")
+    server._github_asf_uid = "alice"
+    server.auth_completed()
+    server._conn.disconnect.assert_called_once_with(asyncssh.DISC_TOO_MANY_CONNECTIONS, "Rate limit exceeded")
+
+
+def test_auth_completed_different_users_are_independent():
+    for _ in range(ssh._RATE_LIMIT_USER):
+        server = _make_server()
+        server._conn = _make_conn_with_username("alice")
+        server.auth_completed()
+    server = _make_server()
+    server._conn = _make_conn_with_username("bob")
+    server.auth_completed()
+    server._conn.disconnect.assert_not_called()
+
+
+# helpers
+
+
+def _make_conn_with_ip(ip: str) -> mock.MagicMock:
+    conn = mock.MagicMock(spec=asyncssh.SSHServerConnection)
+    conn.get_extra_info.return_value = (ip, 22)
+    return conn
+
+
+def _make_conn_with_username(username: str) -> mock.MagicMock:
+    conn = mock.MagicMock(spec=asyncssh.SSHServerConnection)
+    conn.get_extra_info.return_value = username
+    return conn
+
+
+def _make_server() -> ssh.SSHServer:
+    server = ssh.SSHServer.__new__(ssh.SSHServer)
+    server._github_asf_uid = None
+    server._github_payload = None
+    return server


### PR DESCRIPTION
Rate limiting based on IP and username, same as the web side. We IP rate limit in connection start, with a higher limit (to prevent automated attacks but still allow multiple legitimate users from one IP). In auth complete we rate limit per-user - so that we know the username was validated with a key (to prevent malicious usage of another user's rate limit)