### PR TITLE
Adding mermaid back in

### DIFF
--- a/bootstrap/source/package.json
+++ b/bootstrap/source/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "bootstrap": "5.3.8"
+    "bootstrap": "5.3.8",
+    "mermaid": "11.14.0"
   }
 }


### PR DESCRIPTION
## Restore Mermaid in bootstrap dependencies

Fixes #1145
Relates to #1138
Supersedes #1143

### Summary

Mermaid was temporarily removed from the bootstrap build dependencies in commit 22fb628 to clear security checks while waiting for an upstream fix to lodash-es vulnerabilities (CVE-2026-4800, CVE-2026-2950) in Mermaid's dependency chain.

The upstream fix (mermaid-js/mermaid#7587) has shipped in Mermaid 11.14.0, published April 3, 2026. The 7-day cooldown period per our documentation has passed. Snyk reports 11.14.0 as the latest non-vulnerable version.

### Changes

- `bootstrap/source/package.json`: Add `"mermaid": "11.14.0"`

No Dockerfile changes — the base image was already moved to `alpine:edge` which resolves the dart-sass ICU 78 dependency issue from #1138.

### Testing

```bash
$ docker build -t atr-bootstrap bootstrap/context
docker run --rm \
  -v "$PWD/bootstrap/source:/opt/bootstrap/source" \
  atr-bootstrap sh -c "cd /opt/bootstrap/source && npm i --package-lock-only && npm audit && rm package-lock.json"
[+] Building 30.8s (14/14) FINISHED                                                                                          docker:default
[snip]

up to date, audited 131 packages in 2s

found 0 vulnerabilities
found 0 vulnerabilities
```

### Security notes

- `npm audit` should report no lodash-es vulnerabilities with this version
- The lodash-es fix propagated through the dependency chain: mermaid → @mermaid-js/parser → langium → chevrotain → lodash-es
- Version pinned to exact 11.14.0 per our cooldown policy (no `^` or `~` prefix)