### PR TITLE
Adding endpoint to list projects using CI staging

### DIFF
--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 import datetime
 import hashlib
+import re
 from typing import Any, Final, Literal
 
 import aiofiles.os
@@ -57,6 +58,8 @@ import atr.util as util
 
 type DictResponse = tuple[dict[str, Any], int]
 
+AUTOMATED_KEY_PATTERNS: Final = ("Automated Release Signing", "Services RM")
+APACHE_ORG_RE: Final = re.compile(r"([a-z][a-z0-9-]*)\.apache\.org")
 ROUTES_MODULE: Final[Literal[True]] = True
 
 
@@ -824,6 +827,54 @@ async def projects_list(
     return models.api.ProjectsListResults(
         endpoint="/projects/list",
         projects=projects,
+    ).model_dump(mode="json"), 200
+
+
+@api.typed
+@quart_schema.validate_response(models.api.CiStagingListResults, 200)
+async def projects_ci_staging(
+    _projects_ci_staging: Literal["projects/ci-staging"],
+) -> DictResponse:
+    """
+    URL: GET /projects/ci-staging
+
+    List PMCs approved for CI staging.
+
+    Returns projects that have a GitHub repository configured in their
+    release policy, and committee keys that have evidence of automated
+    CI usage (signing keys with automated UIDs). Consumers can join
+    on project.committee_key to determine which projects have both
+    configuration and evidence.
+    """
+    via = sql.validate_instrumented_attribute
+
+    async with db.session() as data:
+        # Evidence: committees with automated signing keys
+        stmt = sqlmodel.select(sql.PublicSigningKey).where(
+            sqlalchemy.or_(
+                *[
+                    via(sql.PublicSigningKey.primary_declared_uid).contains(pattern)
+                    for pattern in AUTOMATED_KEY_PATTERNS
+                ]
+            )
+        )
+        automated_keys = (await data.execute(stmt)).scalars().all()
+
+        evidence_committees: set[str] = set()
+        for key in automated_keys:
+            if key.primary_declared_uid:
+                match = APACHE_ORG_RE.search(key.primary_declared_uid)
+                if match:
+                    evidence_committees.add(match.group(1))
+
+        # Configuration: projects with github repos in release policy
+        all_projects = await data.project(_release_policy=True).all()
+        ci_projects = [p for p in all_projects if p.release_policy and p.release_policy.github_repository_name]
+
+    return models.api.CiStagingListResults(
+        endpoint="/projects/ci-staging",
+        projects=ci_projects,
+        evidence_committee_keys=sorted(evidence_committees),
     ).model_dump(mode="json"), 200
 
 

--- a/atr/models/api.py
+++ b/atr/models/api.py
@@ -42,6 +42,12 @@ class ChecksListResults(schema.Strict):
         return sql.ReleasePhase(v) if isinstance(v, str) else v
 
 
+class CiStagingListResults(schema.Strict):
+    endpoint: Literal["/projects/ci-staging"] = schema.alias("endpoint")
+    projects: Sequence[sql.Project]
+    evidence_committee_keys: Sequence[str]
+
+
 class ChecksOngoingResults(schema.Strict):
     endpoint: Literal["/checks/ongoing"] = schema.alias("endpoint")
     ongoing: int = schema.example(10)


### PR DESCRIPTION
## API to list PMCs approved for CI staging

Fixes #1151

### Summary

New public endpoint `GET /api/projects/ci-staging` that returns projects configured for CI staging and committees that have evidence of CI usage.

Two signals are combined:

1. **Configuration** — projects with `github_repository_name` set in their release policy (returned as `projects`)
2. **Evidence** — committees with automated signing keys whose `primary_declared_uid` contains "Automated Release Signing" or "Services RM" (returned as `evidence_committee_keys`)

Consumers join on `project.committee_key` to determine which projects have both configuration and evidence.

### Changes

- `atr/models/api.py`: Add `CiStagingListResults` response model
- `atr/api/__init__.py`: Add `projects_ci_staging` endpoint and `AUTOMATED_KEY_PATTERNS` / `APACHE_ORG_RE` constants

### Design decisions

- Follows existing api.py conventions: `Sequence[sql.Project]` for projects, flat `Sequence[str]` for evidence keys, no custom sub-models
- Unauthenticated public endpoint, consistent with `/projects/list` and `/committees/list`
- Evidence query mirrors the sqlite3 approach used to generate the initial PMC list for CI onboarding
- Release policy is eagerly loaded so `github_repository_name` and `github_repository_branch` are available on each project without a second request

### Testing

Added a key to `atr.db` and checked for a response:
```bash
$ sqlite3 state/database/atr.db "INSERT INTO publicsigningkey (fingerprint, algorithm, length, created, primary_declared_uid, secondary_declared_uids, ascii_armored_key) VALUES ('deadbeef01234567890123456789012345678901', 22, 256, '2026-01-01T00:00:00', 'Apache Test Automated Release Signing <test.apache.org>', '[]', '-----BEGIN PGP PUBLIC KEY BLOCK-----\ntest\n-----END PGP PUBLIC KEY BLOCK-----');"
Error: stepping, database is locked (5)
$ curl -k https://localhost:8080/api/projects/ci-staging | python3 -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   106  100   106    0     0   3860      0 --:--:-- --:--:-- --:--:--  3925
{
    "endpoint": "/projects/ci-staging",
    "evidence_committee_keys": [
        "test"
    ],
    "projects": []
}
```
