### PR TITLE
#1177 - allow zip format archives (jar, war, apk, vsix, whl, nar, nbm) to be quarantine checked

### DIFF
--- a/atr/analysis.py
+++ b/atr/analysis.py
@@ -26,6 +26,7 @@ import sys
 from typing import Final
 
 ARTIFACT_SUFFIXES: Final[list[str]] = [
+    "apk",
     "bin",
     "crate",
     "deb",

--- a/atr/archives.py
+++ b/atr/archives.py
@@ -17,6 +17,9 @@
 import asyncio
 import contextlib
 import os
+import shutil
+import tempfile
+from collections.abc import Iterator
 from typing import Final
 
 import aiofiles.os
@@ -27,6 +30,28 @@ import atr.log as log
 import atr.models.safe as safe
 
 MAX_ARCHIVE_MEMBERS: Final[int] = 100_000
+
+# Canonical form for archive-suffix aliases. detection.py uses this for
+# quarantine dedup; exarch_compatible_path rewrites filenames with it so
+# exarch accepts them.
+ARCHIVE_NORMALISED_SUFFIXES: Final[dict[str, str]] = {
+    ".tgz": ".tar.gz",
+    ".jar": ".zip",
+    ".war": ".zip",
+    ".whl": ".zip",
+    ".nar": ".zip",
+    ".nbm": ".zip",
+    ".vsix": ".zip",
+    ".apk": ".zip",
+}
+
+# Zip-family aliases exarch doesn't recognise by extension. Derived from
+# ARCHIVE_NORMALISED_SUFFIXES so adding a new .zip-typed alias picks up the
+# hardlink rewrite automatically. .tgz is excluded because exarch handles
+# it natively.
+_EXARCH_REWRITE_SUFFIXES: Final[frozenset[str]] = frozenset(
+    alias for alias, canonical in ARCHIVE_NORMALISED_SUFFIXES.items() if canonical == ".zip"
+)
 
 
 class ExtractionError(Exception):
@@ -47,21 +72,22 @@ def extract(
     cfg = _build_extraction_config(max_size)
     extracted_paths: list[str] = []
 
-    if isinstance(track_files, set) and track_files:
-        try:
-            manifest = exarch.list_archive(str(archive_path), cfg)
-        except Exception as exc:
-            raise ExtractionError(f"Failed to list archive: {exc}") from exc
-        for entry in manifest.entries:
-            if os.path.basename(entry.path) in track_files:
-                extracted_paths.append(entry.path)
+    with exarch_compatible_path(archive_path) as exarch_path:
+        if isinstance(track_files, set) and track_files:
+            try:
+                manifest = exarch.list_archive(exarch_path, cfg)
+            except Exception as exc:
+                raise ExtractionError(f"Failed to list archive: {exc}") from exc
+            for entry in manifest.entries:
+                if os.path.basename(entry.path) in track_files:
+                    extracted_paths.append(entry.path)
 
-    try:
-        report = exarch.extract_archive(str(archive_path), extract_dir, cfg)
-    except exarch.QuotaExceededError as exc:
-        raise ExtractionError(f"Extraction exceeded size limit of {max_size} bytes: {exc}") from exc
-    except Exception as exc:
-        raise ExtractionError(f"Failed to extract archive: {exc}") from exc
+        try:
+            report = exarch.extract_archive(exarch_path, extract_dir, cfg)
+        except exarch.QuotaExceededError as exc:
+            raise ExtractionError(f"Extraction exceeded size limit of {max_size} bytes: {exc}") from exc
+        except Exception as exc:
+            raise ExtractionError(f"Failed to extract archive: {exc}") from exc
 
     return report.bytes_written, extracted_paths
 
@@ -90,6 +116,29 @@ async def list_archive(file_path: safe.StatePath) -> list[str] | None:
         return None
 
     return await asyncio.to_thread(_read_archive)
+
+
+@contextlib.contextmanager
+def exarch_compatible_path(archive_path: safe.StatePath) -> Iterator[str]:
+    # exarch dispatches on extension and doesn't recognise .jar/.war/.whl.
+    # For those, hardlink under a .zip name in a tempdir and hand exarch that.
+    source = archive_path.path
+    lower_name = source.name.lower()
+    alias = next((s for s in _EXARCH_REWRITE_SUFFIXES if lower_name.endswith(s)), None)
+    if alias is None:
+        yield str(source)
+        return
+    canonical = ARCHIVE_NORMALISED_SUFFIXES[alias]
+    # Hardlinks can't cross filesystems, so the tempdir has to sit next to
+    # the source. /tmp can be a separate tmpfs partition which would
+    # fail with EXDEV.
+    tmp_dir = tempfile.mkdtemp(prefix="atr-exarch-", dir=str(source.parent))
+    try:
+        link_path = os.path.join(tmp_dir, f"archive{canonical}")
+        os.link(source, link_path)
+        yield link_path
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def _build_extraction_config(max_extract_size: int) -> exarch.SecurityConfig:

--- a/atr/classify.py
+++ b/atr/classify.py
@@ -169,7 +169,7 @@ async def classify(
     if (binary_matcher is not None) and (abs_str is not None) and binary_matcher(abs_str):
         return FileType.BINARY
     stem = path_str[: search.start()]
-    if not any(path_str.endswith(suffix) for suffix in detection.QUARANTINE_ARCHIVE_SUFFIXES):
+    if not any(path_str.endswith(suffix) for suffix in detection.CLASSIFY_ARCHIVE_SUFFIXES):
         return FileType.BINARY
     if archive_cache_dir is not None:
         marker = await _content_markers(archive_cache_dir)

--- a/atr/detection.py
+++ b/atr/detection.py
@@ -20,11 +20,30 @@ from typing import Final
 
 import puremagic
 
+import atr.archives as archives
 import atr.models.attestable as models
 import atr.models.safe as safe
 
-# TODO: Widen the range of types checked here
-QUARANTINE_ARCHIVE_SUFFIXES: Final[tuple[str, ...]] = (".tar.gz", ".tgz", ".zip")
+# Archive suffixes the source/binary classifier will peek inside. Zip-family
+# aliases (.jar/.war/.whl) are deliberately excluded - they were not in the existing
+# classified list when we added support
+CLASSIFY_ARCHIVE_SUFFIXES: Final[tuple[str, ...]] = (".tar.gz", ".tgz", ".zip")
+
+# Archive suffixes that trigger a quarantine safety scan. Aliases normalise
+# to canonical form via archives.ARCHIVE_NORMALISED_SUFFIXES for dedup and
+# for the exarch filename rewrite.
+QUARANTINE_ARCHIVE_SUFFIXES: Final[tuple[str, ...]] = (
+    ".tar.gz",
+    ".tgz",
+    ".zip",
+    ".jar",
+    ".war",
+    ".whl",
+    ".nar",
+    ".nbm",
+    ".vsix",
+    ".apk",
+)
 
 _BZIP2_TYPES: Final[set[str]] = {"application/x-bzip2"}
 _DEB_TYPES: Final[set[str]] = {"application/vnd.debian.binary-package", "application/x-archive"}
@@ -35,9 +54,12 @@ _RPM_TYPES: Final[set[str]] = {"application/x-rpm"}
 _TAR_TYPES: Final[set[str]] = {"application/x-tar"}
 _XZ_TYPES: Final[set[str]] = {"application/x-xz"}
 _ZIP_TYPES: Final[set[str]] = {"application/zip", "application/java-archive"}
+# puremagic identifies modern APKs via their own mime type rather than zip,
+# so the accept set is zip-types plus the Android-specific one.
+_APK_TYPES: Final[set[str]] = _ZIP_TYPES | {"application/vnd.android.package-archive"}
 
 _EXPECTED: Final[dict[str, set[str]]] = {
-    ".apk": _ZIP_TYPES,
+    ".apk": _APK_TYPES,
     ".bin.zip": _ZIP_TYPES,
     ".deb": _DEB_TYPES,
     ".exe": _EXE_TYPES,
@@ -61,7 +83,6 @@ _EXPECTED: Final[dict[str, set[str]]] = {
 }
 
 _COMPOUND_SUFFIXES: Final = tuple(s for s in _EXPECTED if s.count(".") > 1)
-_QUARANTINE_NORMALISED_SUFFIXES: Final[dict[str, str]] = {".tgz": ".tar.gz"}
 
 
 def deduplicate_quarantine_archives(
@@ -107,6 +128,10 @@ def detect_archives_requiring_quarantine(
             quarantine_paths.append(path_key)
 
     return quarantine_paths
+
+
+def is_quarantine_archive(filename: str) -> bool:
+    return _quarantine_archive_suffix(filename) is not None
 
 
 def validate_directory(directory: pathlib.Path) -> list[str]:
@@ -158,7 +183,7 @@ def _quarantine_archive_suffix(filename: str) -> str | None:
     lower_name = filename.lower()
     for suffix in QUARANTINE_ARCHIVE_SUFFIXES:
         if lower_name.endswith(suffix):
-            return _QUARANTINE_NORMALISED_SUFFIXES.get(suffix, suffix)
+            return archives.ARCHIVE_NORMALISED_SUFFIXES.get(suffix, suffix)
     return None
 
 

--- a/atr/tasks/quarantine.py
+++ b/atr/tasks/quarantine.py
@@ -161,7 +161,7 @@ def _backfill_revision(
     for archive_path in sorted(revision_dir_path.rglob("*")):
         if not archive_path.is_file():
             continue
-        if not _is_archive_suffix(archive_path.name):
+        if not detection.is_quarantine_archive(archive_path.name):
             continue
         content_hash = hashes.compute_file_hash_sync(archive_path)
         archive_key = hashes.filesystem_archives_key(content_hash)
@@ -210,7 +210,8 @@ def _extract_archive_to_dir(
     try:
         staging_dir_path.mkdir(parents=False, exist_ok=False)
         start = time.monotonic()
-        exarch.extract_archive(str(archive_path), str(staging_dir), extraction_cfg)
+        with archives.exarch_compatible_path(archive_path) as exarch_path:
+            exarch.extract_archive(exarch_path, str(staging_dir), extraction_cfg)
         archive_dir_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             os.rename(staging_dir, archive_dir)
@@ -260,11 +261,6 @@ async def _extract_archives(
                     entry.errors.append(f"Extraction failed: {exc}")
                     break
             raise
-
-
-def _is_archive_suffix(filename: str) -> bool:
-    lower_name = filename.lower()
-    return any(lower_name.endswith(suffix) for suffix in detection.QUARANTINE_ARCHIVE_SUFFIXES)
 
 
 async def _mark_failed(

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -1,0 +1,207 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import io
+import pathlib
+import tarfile
+import zipfile
+
+import pytest
+
+import atr.archives as archives
+import atr.models.safe as safe
+
+
+def test_extract_tar_gz_returns_total_size_and_empty_paths_by_default(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.tar.gz"
+    _make_tar_gz(archive_path, [("a.txt", b"aaaa"), ("dir/b.txt", b"bbbbbb")])
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    total, extracted = archives.extract(
+        safe.StatePath(archive_path),
+        str(extract_dir),
+        max_size=1024 * 1024,
+        chunk_size=1024,
+    )
+
+    assert total == 10
+    assert extracted == []
+    assert (extract_dir / "a.txt").read_bytes() == b"aaaa"
+    assert (extract_dir / "dir" / "b.txt").read_bytes() == b"bbbbbb"
+
+
+def test_extract_zip_returns_total_size_and_empty_paths_by_default(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.zip"
+    _make_zip(archive_path, [("a.txt", b"aaaa"), ("dir/b.txt", b"bbbbbb")])
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    total, extracted = archives.extract(
+        safe.StatePath(archive_path),
+        str(extract_dir),
+        max_size=1024 * 1024,
+        chunk_size=1024,
+    )
+
+    assert total == 10
+    assert extracted == []
+    assert (extract_dir / "a.txt").read_bytes() == b"aaaa"
+
+
+def test_extract_tar_gz_track_files_records_matching_basenames(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.tar.gz"
+    _make_tar_gz(archive_path, [("root/pom.xml", b"<x/>"), ("root/README.md", b"r"), ("root/src/x.java", b"j")])
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    extracted = archives.extract(
+        safe.StatePath(archive_path),
+        str(extract_dir),
+        max_size=1024 * 1024,
+        chunk_size=1024,
+        track_files={"pom.xml"},
+    )[1]
+
+    assert extracted == ["root/pom.xml"]
+
+
+def test_extract_zip_track_files_records_matching_basenames(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.zip"
+    _make_zip(archive_path, [("root/pom.xml", b"<x/>"), ("root/README.md", b"r")])
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    extracted = archives.extract(
+        safe.StatePath(archive_path),
+        str(extract_dir),
+        max_size=1024 * 1024,
+        chunk_size=1024,
+        track_files={"pom.xml"},
+    )[1]
+
+    assert extracted == ["root/pom.xml"]
+
+
+def test_extract_preserves_dot_underscore_metadata_files_tar(tmp_path: pathlib.Path) -> None:
+    # Exarch faithfully extracts AppleDouble (._*) metadata members.
+    # The previous hand-rolled implementation silently dropped them; quarantine
+    # extraction has always retained them, so this aligns SBOM with quarantine.
+    archive_path = tmp_path / "sample.tar.gz"
+    _make_tar_gz(archive_path, [("a.txt", b"aaaa"), ("._a.txt", b"metadata")])
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    total, _ = archives.extract(
+        safe.StatePath(archive_path),
+        str(extract_dir),
+        max_size=1024 * 1024,
+        chunk_size=1024,
+    )
+
+    assert total == 12
+    assert (extract_dir / "a.txt").exists()
+    assert (extract_dir / "._a.txt").exists()
+
+
+def test_extract_raises_when_exceeding_max_size(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.tar.gz"
+    _make_tar_gz(archive_path, [("big.bin", b"x" * 5000)])
+    extract_dir = tmp_path / "out"
+    extract_dir.mkdir()
+
+    with pytest.raises(archives.ExtractionError):
+        archives.extract(
+            safe.StatePath(archive_path),
+            str(extract_dir),
+            max_size=1000,
+            chunk_size=1024,
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_archive_tar_gz_returns_sorted_member_names(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.tar.gz"
+    _make_tar_gz(archive_path, [("b.txt", b"b"), ("a.txt", b"a"), ("dir/c.txt", b"c")])
+
+    result = await archives.list_archive(safe.StatePath(archive_path))
+
+    assert result == ["a.txt", "b.txt", "dir/c.txt"]
+
+
+@pytest.mark.asyncio
+async def test_list_archive_tgz_extension_is_recognised(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.tgz"
+    _make_tar_gz(archive_path, [("a.txt", b"a")])
+
+    result = await archives.list_archive(safe.StatePath(archive_path))
+
+    assert result == ["a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_list_archive_zip_returns_sorted_member_names(tmp_path: pathlib.Path) -> None:
+    archive_path = tmp_path / "sample.zip"
+    _make_zip(archive_path, [("b.txt", b"b"), ("a.txt", b"a")])
+
+    result = await archives.list_archive(safe.StatePath(archive_path))
+
+    assert result == ["a.txt", "b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_list_archive_returns_none_for_missing_file(tmp_path: pathlib.Path) -> None:
+    missing = tmp_path / "nope.tar.gz"
+
+    # StatePath requires the root to exist; use tmp_path as root to keep the path valid.
+    result = await archives.list_archive(safe.StatePath(missing, root=tmp_path))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_list_archive_returns_none_for_unsupported_extension(tmp_path: pathlib.Path) -> None:
+    other = tmp_path / "sample.rar"
+    other.write_bytes(b"not an archive")
+
+    result = await archives.list_archive(safe.StatePath(other))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_list_archive_returns_none_for_corrupt_archive(tmp_path: pathlib.Path) -> None:
+    corrupt = tmp_path / "corrupt.zip"
+    corrupt.write_bytes(b"not actually a zip")
+
+    result = await archives.list_archive(safe.StatePath(corrupt))
+
+    assert result is None
+
+
+def _make_tar_gz(path: pathlib.Path, members: list[tuple[str, bytes]]) -> None:
+    with tarfile.open(path, "w:gz") as tf:
+        for name, data in members:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+
+def _make_zip(path: pathlib.Path, members: list[tuple[str, bytes]]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in members:
+            zf.writestr(name, data)

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
+
 import atr.detection as detection
 import atr.models.attestable as models
 
@@ -164,3 +166,94 @@ def test_detect_archives_requiring_quarantine_tgz_and_tar_gz_are_equivalent():
     )
 
     assert result == []
+
+
+@pytest.mark.parametrize("alias", [".jar", ".war", ".whl", ".nar", ".nbm", ".vsix", ".apk"])
+def test_deduplicate_quarantine_archives_zip_family_aliases_collapse_with_zip(alias):
+    paths_list = [f"a/artifact{alias}", "b/artifact.zip"]
+    path_to_hash = {f"a/artifact{alias}": "h1", "b/artifact.zip": "h1"}
+
+    result = detection.deduplicate_quarantine_archives(paths_list, path_to_hash)
+
+    assert len(result) == 1
+
+
+@pytest.mark.parametrize("suffix", [".jar", ".war", ".whl", ".nar", ".nbm", ".vsix", ".apk"])
+def test_detect_archives_requiring_quarantine_zip_family_new_upload(suffix):
+    result = detection.detect_archives_requiring_quarantine(
+        path_to_hash={f"dist/widget{suffix}": "h1"},
+        previous_attestable=None,
+    )
+
+    assert result == [f"dist/widget{suffix}"]
+
+
+@pytest.mark.parametrize(
+    ("prev_suffix", "new_suffix"),
+    [
+        (".jar", ".zip"),
+        (".war", ".zip"),
+        (".whl", ".zip"),
+        (".nar", ".zip"),
+        (".nbm", ".zip"),
+        (".vsix", ".zip"),
+        (".apk", ".zip"),
+        (".jar", ".war"),
+        (".war", ".whl"),
+        (".nar", ".nbm"),
+        (".vsix", ".apk"),
+    ],
+)
+def test_detect_archives_requiring_quarantine_zip_family_aliases_are_equivalent(prev_suffix, new_suffix):
+    previous = models.AttestableV1(
+        paths={f"dist/widget{prev_suffix}": "h1"},
+        hashes={
+            "h1": models.HashEntry(
+                size=100,
+                uploaders=[("alice", "00001")],
+                basenames=[f"widget{prev_suffix}"],
+            )
+        },
+        policy={},
+    )
+
+    result = detection.detect_archives_requiring_quarantine(
+        path_to_hash={f"dist/widget{new_suffix}": "h1"},
+        previous_attestable=previous,
+    )
+
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "a.tar.gz",
+        "a.tgz",
+        "a.zip",
+        "a.jar",
+        "a.war",
+        "a.whl",
+        "a.nar",
+        "a.nbm",
+        "a.vsix",
+        "a.apk",
+        "FOO.JAR",
+        "Widget-1.0.War",
+        "package-1.0.WHL",
+        "processor-1.0.NAR",
+        "module-1.0.NBM",
+        "extension-1.0.VSIX",
+        "app-1.0.APK",
+    ],
+)
+def test_is_quarantine_archive_accepts_zip_family_and_tar_family(filename):
+    assert detection.is_quarantine_archive(filename) is True
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["README.md", "KEYS", "widget.txt", "widget.tar.gz.asc", "widget.tar", "widget.7z"],
+)
+def test_is_quarantine_archive_rejects_non_quarantine_files(filename):
+    assert detection.is_quarantine_archive(filename) is False


### PR DESCRIPTION
Adds a function to the quarantine process to create a temporary hard link with the `.zip` extension, for those file formats we know to be zip formatted internally. Exarch can then unzip them for safety checking.

I haven't added support to list the contents like we do for zip etc. - that would be essentially trivial using the same method if we wanted to.

I've added some tests but have also downloaded a file of each type and ensured they trigger the quarantine step. 