### PR TITLE
Fix env var for expected secret crashes server

### DIFF
--- a/atr/config.py
+++ b/atr/config.py
@@ -49,12 +49,11 @@ def _config_secrets_get(
         if allow_not_found is False:
             raise
     else:
-        if key in repo_ini:
-            try:
-                value = repo_ini[key]
-                return cast(value)
-            except KeyError:
-                pass
+        try:
+            value = repo_ini[key]
+            return cast(value)
+        except KeyError:
+            pass
 
     # There is no secrets file, or it does not contain the key
     # Try getting the value from environment variables

--- a/atr/config.py
+++ b/atr/config.py
@@ -50,8 +50,11 @@ def _config_secrets_get(
             raise
     else:
         if key in repo_ini:
-            value = repo_ini[key]
-            return cast(value)
+            try:
+                value = repo_ini[key]
+                return cast(value)
+            except KeyError:
+                pass
 
     # There is no secrets file, or it does not contain the key
     # Try getting the value from environment variables


### PR DESCRIPTION
closes #948 

I noticed that configured secrets take precedence over environment variables. Perhaps it should be the other way around.