### PR TITLE
Api auth decorators 1169

### DIFF
--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -372,14 +372,16 @@ async def distribute_ssh_register(
         vars(data)["ssh_key"] = ""
         gc.collect()
         raise exceptions.BadRequest(util.PRIVATE_KEY_UPLOAD_WARNING)
-    payload, asf_uid, project, release = await interaction.trusted_jwt_for_dist(
-        data.publisher,
-        data.jwt,
+    ctx = api.auth.trusted_publisher_context()
+    project, release = await interaction.trusted_release_for_payload(
+        ctx.asf_uid,
         data.asf_uid,
         interaction.TrustedProjectPhase(data.phase),
         data.project_key,
         data.version,
     )
+    asf_uid = data.asf_uid
+    payload = ctx.payload
     # Validate that the task ID passed exists and was started by the UID asserted
     async with db.session() as _data:
         await _data.task(id=int(data.task_id), asf_uid=data.asf_uid).demand(exceptions.NotFound("Task not found"))
@@ -457,9 +459,9 @@ async def distribution_record_from_workflow(
     Validates the caller is a Github workflow, triggered by ATR itself
     """
 
-    _payload, _asf_uid, _project, release = await interaction.trusted_jwt_for_dist(
-        data.publisher,
-        data.jwt,
+    ctx = api.auth.trusted_publisher_context()
+    _project, release = await interaction.trusted_release_for_payload(
+        ctx.asf_uid,
         data.asf_uid,
         interaction.TrustedProjectPhase(data.phase),
         data.project,
@@ -867,8 +869,6 @@ async def policy_update(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ProjectConfigResults, 200)
 async def project_config_upsert(
     _project_config: Literal["project/config"],
@@ -972,17 +972,18 @@ async def publisher_distribution_record(
 
     Record a distribution with a corroborating Trusted Publisher JWT.
     """
+    ctx = api.auth.trusted_publisher_context()
     try:
-        _payload, asf_uid, project = await interaction.trusted_jwt(
-            data.publisher,
-            data.jwt,
+        asf_uid, project = await interaction.trusted_project_for_payload(
+            ctx.payload,
+            ctx.asf_uid,
             interaction.TrustedProjectPhase.FINISH,
         )
     except interaction.ReleasePolicyNotFoundError:
         # TODO: We could perform a more advanced query with multiple in_ statements
-        _payload, asf_uid, project = await interaction.trusted_jwt(
-            data.publisher,
-            data.jwt,
+        asf_uid, project = await interaction.trusted_project_for_payload(
+            ctx.payload,
+            ctx.asf_uid,
             interaction.TrustedProjectPhase.COMPOSE,
         )
     util.validate_distribution_owner_namespace(data.platform, data.distribution_owner_namespace)
@@ -1025,9 +1026,10 @@ async def publisher_release_announce(
 
     Announce a release with a corroborating Trusted Publisher JWT.
     """
-    _payload, asf_uid, project = await interaction.trusted_jwt(
-        data.publisher,
-        data.jwt,
+    ctx = api.auth.trusted_publisher_context()
+    asf_uid, project = await interaction.trusted_project_for_payload(
+        ctx.payload,
+        ctx.asf_uid,
         interaction.TrustedProjectPhase.FINISH,
     )
     try:
@@ -1068,9 +1070,13 @@ async def publisher_ssh_register(
         vars(data)["ssh_key"] = ""
         gc.collect()
         raise exceptions.BadRequest(util.PRIVATE_KEY_UPLOAD_WARNING)
-    payload, asf_uid, project = await interaction.trusted_jwt(
-        data.publisher, data.jwt, interaction.TrustedProjectPhase.COMPOSE
+    ctx = api.auth.trusted_publisher_context()
+    asf_uid, project = await interaction.trusted_project_for_payload(
+        ctx.payload,
+        ctx.asf_uid,
+        interaction.TrustedProjectPhase.COMPOSE,
     )
+    payload = ctx.payload
     async with storage.write_as_committee_member(util.unwrap(project.committee).key, asf_uid) as wacm:
         fingerprint, expires = await wacm.ssh.add_workflow_key(
             payload.actor,
@@ -1100,9 +1106,10 @@ async def publisher_vote_resolve(
     Resolve a vote with a corroborating Trusted Publisher JWT.
     """
     # TODO: Need to be able to resolve and make the release immutable
-    _payload, asf_uid, project = await interaction.trusted_jwt(
-        data.publisher,
-        data.jwt,
+    ctx = api.auth.trusted_publisher_context()
+    asf_uid, project = await interaction.trusted_project_for_payload(
+        ctx.payload,
+        ctx.asf_uid,
         interaction.TrustedProjectPhase.VOTE,
     )
     try:
@@ -1571,9 +1578,9 @@ async def update_distribution_task_status(
     Update the status of a distribution task
     Validates the caller is a Github workflow, triggered by ATR itself
     """
-    _payload, asf_uid = await interaction.validate_trusted_jwt(data.publisher, data.jwt)
+    ctx = api.auth.trusted_publisher_context()
     # If UID is not none, this is a non-ATR workflow, which is unsupported.
-    if asf_uid is not None:
+    if ctx.asf_uid is not None:
         raise exceptions.Forbidden("This endpoint may only be called by ATR")
     async with db.session() as db_data:
         status = await db_data.workflow_status(

--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -35,7 +35,6 @@ import atr.config as config
 import atr.db as db
 import atr.db.interaction as interaction
 import atr.hashes as hashes
-import atr.jwtoken as jwtoken
 import atr.ldap as ldap
 import atr.log as log
 import atr.models as models
@@ -403,8 +402,6 @@ async def distribute_ssh_register(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.DistributionRecordResults, 200)
 async def distribution_record(
     _distribution_record: Literal["distribution/record"],
@@ -497,8 +494,6 @@ async def distribution_record_from_workflow(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.IgnoreAddResults, 200)
 async def ignore_add(
     _ignore_add: Literal["ignore/add"],
@@ -532,8 +527,6 @@ async def ignore_add(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.IgnoreDeleteResults, 200)
 async def ignore_delete(
     _ignore_delete: Literal["ignore/delete"],
@@ -612,8 +605,6 @@ async def jwt_create(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.KeyAddResults, 200)
 async def key_add(
     _key_add: Literal["key/add"],
@@ -655,8 +646,6 @@ async def key_add(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.KeyDeleteResults, 200)
 async def key_delete(
     _key_delete: Literal["key/delete"],
@@ -720,8 +709,6 @@ async def key_get(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.KeysUploadResults, 200)
 async def keys_upload(
     _keys_upload: Literal["keys/upload"],
@@ -852,8 +839,6 @@ async def policy_get(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.PolicyUpdateResults, 200)
 async def policy_update(
     _policy_update: Literal["policy/update"],
@@ -1143,8 +1128,6 @@ async def publisher_vote_resolve(
 @api.typed
 @rate_limiter.rate_limit(5, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseAnnounceResults, 201)
 async def release_announce(
     _release_announce: Literal["release/announce"],
@@ -1186,8 +1169,6 @@ async def release_announce(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseCreateResults, 201)
 async def release_create(
     _release_create: Literal["release/create"],
@@ -1218,8 +1199,6 @@ async def release_create(
 # TODO: Duplicates the below
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseDeleteResults, 200)
 async def release_delete(
     _release_delete: Literal["release/delete"],
@@ -1327,8 +1306,6 @@ async def release_revisions(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseUploadResults, 201)
 async def release_upload(
     _release_upload: Literal["release/upload"],
@@ -1420,8 +1397,6 @@ async def releases_list(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.SignatureProvenanceResults, 200)
 async def signature_provenance(
     _signature_provenance: Literal["signature/provenance"],
@@ -1495,8 +1470,6 @@ async def signature_provenance(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.SshKeyAddResults, 201)
 async def ssh_key_add(
     _ssh_key_add: Literal["ssh-key/add"],
@@ -1526,8 +1499,6 @@ async def ssh_key_add(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.SshKeyDeleteResults, 201)
 async def ssh_key_delete(
     _ssh_key_delete: Literal["ssh-key/delete"],
@@ -1622,8 +1593,6 @@ async def update_distribution_task_status(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.UserInfoResults, 200)
 async def user_info(
     _user_info: Literal["user/info"],
@@ -1689,8 +1658,7 @@ async def users_list(
 
 @api.typed
 @rate_limiter.rate_limit(60, datetime.timedelta(hours=1))
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
+@api.auth.bearer
 @quart_schema.validate_response(models.api.VoteCastResults, 200)
 async def vote_cast(
     _vote_cast: Literal["vote/cast"],
@@ -1729,8 +1697,6 @@ async def vote_cast(
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.VoteResolveResults, 200)
 async def vote_resolve(
     _vote_resolve: Literal["vote/resolve"],
@@ -1773,8 +1739,6 @@ async def vote_resolve(
 @api.typed
 @rate_limiter.rate_limit(5, datetime.timedelta(hours=1))
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.VoteStartResults, 201)
 async def vote_start(
     _vote_start: Literal["vote/start"],
@@ -1838,8 +1802,6 @@ async def vote_start(
 
 @api.typed
 @api.auth.bearer
-@jwtoken.require
-@quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.VoteTabulateResults, 200)
 async def vote_tabulate(
     _vote_tabulate: Literal["vote/tabulate"],

--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -65,6 +65,7 @@ ROUTES_MODULE: Final[Literal[True]] = True
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ChecksListResults, 200)
 async def checks_list(
     _checks_list: Literal["checks/list"],
@@ -99,6 +100,7 @@ async def checks_list(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ChecksListResults, 200)
 async def checks_list_revision(
     _checks_list: Literal["checks/list"],
@@ -140,6 +142,7 @@ async def checks_list_revision(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ChecksOngoingResults, 200)
 async def checks_ongoing(
     _checks_ongoing: Literal["checks/ongoing"],
@@ -178,6 +181,7 @@ async def checks_ongoing(
 
 
 @api.typed
+@api.auth.public
 async def cle_project(
     _cle_project: Literal["cle/project"],
     project_key: safe.ProjectKey,
@@ -207,6 +211,7 @@ async def cle_project(
 
 
 @api.typed
+@api.auth.public
 async def cle_release(
     _cle_release: Literal["cle/release"],
     project_key: safe.ProjectKey,
@@ -250,6 +255,7 @@ async def cle_release(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.CommitteeGetResults, 200)
 async def committee_get(
     _committee_get: Literal["committee/get"],
@@ -276,6 +282,7 @@ async def committee_get(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.CommitteeKeysResults, 200)
 async def committee_keys(
     _committee_keys: Literal["committee/keys"],
@@ -302,6 +309,7 @@ async def committee_keys(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.CommitteeProjectsResults, 200)
 async def committee_projects(
     _committee_projects: Literal["committee/projects"],
@@ -328,6 +336,7 @@ async def committee_projects(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.CommitteesListResults, 200)
 async def committees_list(
     _committees_list: Literal["committees/list"],
@@ -349,6 +358,7 @@ async def committees_list(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.body_oidc
 async def distribute_ssh_register(
     _distribute_ssh_register: Literal["distribute/ssh/register"],
     data: models.api.DistributeSshRegisterArgs,
@@ -392,6 +402,7 @@ async def distribute_ssh_register(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.DistributionRecordResults, 200)
@@ -437,6 +448,7 @@ async def distribution_record(
 
 
 @api.typed
+@api.auth.body_oidc
 async def distribution_record_from_workflow(
     _distribute_record_from_workflow: Literal["distribute/record_from_workflow"],
     data: models.api.DistributionRecordFromWorkflowArgs,
@@ -484,6 +496,7 @@ async def distribution_record_from_workflow(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.IgnoreAddResults, 200)
@@ -518,6 +531,7 @@ async def ignore_add(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.IgnoreDeleteResults, 200)
@@ -546,6 +560,7 @@ async def ignore_delete(
 
 # TODO: Rename to ignores
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.IgnoreListResults, 200)
 async def ignore_list(
     _ignore_list: Literal["ignore/list"],
@@ -567,6 +582,7 @@ async def ignore_list(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.pat
 async def jwt_create(
     _jwt_create: Literal["jwt/create"],
     data: models.api.JwtCreateArgs,
@@ -595,6 +611,7 @@ async def jwt_create(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.KeyAddResults, 200)
@@ -637,6 +654,7 @@ async def key_add(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.KeyDeleteResults, 200)
@@ -676,6 +694,7 @@ async def key_delete(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.public
 @quart_schema.validate_response(models.api.KeyGetResults, 200)
 async def key_get(
     _key_get: Literal["key/get"],
@@ -700,6 +719,7 @@ async def key_get(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.KeysUploadResults, 200)
@@ -767,6 +787,7 @@ async def keys_upload(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.public
 @quart_schema.validate_response(models.api.KeysUserResults, 200)
 async def keys_user(
     _keys_user: Literal["keys/user"],
@@ -786,6 +807,7 @@ async def keys_user(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.PolicyGetResults, 200)
 async def policy_get(
     _policy_get: Literal["policy/get"],
@@ -829,6 +851,7 @@ async def policy_get(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.PolicyUpdateResults, 200)
@@ -858,6 +881,7 @@ async def policy_update(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ProjectConfigResults, 200)
@@ -872,6 +896,7 @@ async def project_config_upsert(
 
     Creates a project if it on by the specified key does not yet exist.
     Otherwise, updates all specified fields for an existing project.
+
     The caller must be a committee member of the specified committee,
     and for an existing project committee_key must match the current value.
     """
@@ -891,6 +916,7 @@ async def project_config_upsert(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ProjectGetResults, 200)
 async def project_get(
     _project_get: Literal["project/get"],
@@ -910,6 +936,7 @@ async def project_get(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ProjectReleasesResults, 200)
 async def project_releases(
     _project_releases: Literal["project/releases"],
@@ -930,6 +957,7 @@ async def project_releases(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ProjectsListResults, 200)
 async def projects_list(
     _projects_list: Literal["projects/list"],
@@ -949,6 +977,7 @@ async def projects_list(
 
 
 @api.typed
+@api.auth.body_oidc
 async def publisher_distribution_record(
     _publisher_distribution_record: Literal["publisher/distribution/record"],
     data: models.api.PublisherDistributionRecordArgs,
@@ -1001,6 +1030,7 @@ async def publisher_distribution_record(
 
 
 @api.typed
+@api.auth.body_oidc
 async def publisher_release_announce(
     _publisher_release_announce: Literal["publisher/release/announce"],
     data: models.api.PublisherReleaseAnnounceArgs,
@@ -1039,6 +1069,7 @@ async def publisher_release_announce(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.body_oidc
 async def publisher_ssh_register(
     _publisher_ssh_register: Literal["publisher/ssh/register"],
     data: models.api.PublisherSshRegisterArgs,
@@ -1073,6 +1104,7 @@ async def publisher_ssh_register(
 
 
 @api.typed
+@api.auth.body_oidc
 async def publisher_vote_resolve(
     _publisher_vote_resolve: Literal["publisher/vote/resolve"],
     data: models.api.PublisherVoteResolveArgs,
@@ -1110,6 +1142,7 @@ async def publisher_vote_resolve(
 
 @api.typed
 @rate_limiter.rate_limit(5, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseAnnounceResults, 201)
@@ -1152,6 +1185,7 @@ async def release_announce(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseCreateResults, 201)
@@ -1183,6 +1217,7 @@ async def release_create(
 
 # TODO: Duplicates the below
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseDeleteResults, 200)
@@ -1212,6 +1247,7 @@ async def release_delete(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ReleaseGetResults, 200)
 async def release_get(
     _release_get: Literal["release/get"],
@@ -1233,6 +1269,7 @@ async def release_get(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ReleasePathsResults, 200)
 async def release_paths(
     _release_paths: Literal["release/paths"],
@@ -1264,6 +1301,7 @@ async def release_paths(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ReleaseRevisionsResults, 200)
 async def release_revisions(
     _release_revisions: Literal["release/revisions"],
@@ -1288,6 +1326,7 @@ async def release_revisions(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.ReleaseUploadResults, 201)
@@ -1329,6 +1368,7 @@ async def release_upload(
 
 
 @api.typed
+@api.auth.public
 @quart_schema.validate_response(models.api.ReleasesListResults, 200)
 async def releases_list(
     _releases_list: Literal["releases/list"],
@@ -1379,6 +1419,7 @@ async def releases_list(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.SignatureProvenanceResults, 200)
@@ -1453,6 +1494,7 @@ async def signature_provenance(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.SshKeyAddResults, 201)
@@ -1483,6 +1525,7 @@ async def ssh_key_add(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.SshKeyDeleteResults, 201)
@@ -1509,6 +1552,7 @@ async def ssh_key_delete(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.public
 async def ssh_keys_list(
     _ssh_keys_list: Literal["ssh-keys/list"],
     asf_uid: unsafe.UnsafeStr,
@@ -1545,6 +1589,7 @@ async def ssh_keys_list(
 
 
 @api.typed
+@api.auth.body_oidc
 async def update_distribution_task_status(
     _distribute_task_status: Literal["distribute/task/status"],
     data: models.api.DistributeStatusUpdateArgs,
@@ -1576,6 +1621,7 @@ async def update_distribution_task_status(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.UserInfoResults, 200)
@@ -1600,6 +1646,7 @@ async def user_info(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.public
 @quart_schema.validate_response(models.api.UsersListResults, 200)
 async def users_list(
     _users_list: Literal["users/list"],
@@ -1681,6 +1728,7 @@ async def vote_cast(
 
 @api.typed
 @rate_limiter.rate_limit(10, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.VoteResolveResults, 200)
@@ -1724,6 +1772,7 @@ async def vote_resolve(
 
 @api.typed
 @rate_limiter.rate_limit(5, datetime.timedelta(hours=1))
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.VoteStartResults, 201)
@@ -1788,6 +1837,7 @@ async def vote_start(
 
 
 @api.typed
+@api.auth.bearer
 @jwtoken.require
 @quart_schema.security_scheme([{"BearerAuth": []}])
 @quart_schema.validate_response(models.api.VoteTabulateResults, 200)

--- a/atr/blueprints/api.py
+++ b/atr/blueprints/api.py
@@ -36,13 +36,12 @@ import atr.log as log
 import atr.storage as storage
 import atr.web as web
 
-# Re-export so routes can write `@api.auth.public` etc. (matches #1169).
-# We also keep `auth` importable as a plain attribute for tests.
 __all__ = ["auth", "register", "typed"]
 
 _BLUEPRINT_NAME: Final = "api_blueprint"
 _BLUEPRINT: Final = quart.Blueprint(_BLUEPRINT_NAME, __name__, url_prefix="/api")
 _routes: list[str] = []
+_route_auth_levels: dict[str, auth.AuthLevel] = {}
 
 
 def register(app: base.QuartApp) -> tuple[ModuleType, list[str]]:
@@ -52,16 +51,8 @@ def register(app: base.QuartApp) -> tuple[ModuleType, list[str]]:
     return api, _routes
 
 
-# Registry of (function name -> auth level) captured at import time.
-# Populated by typed() and consumed by tests/unit/test_api_auth_decorators.py.
-_route_auth_levels: dict[str, auth.AuthLevel] = {}
-
-
 def route_auth_levels() -> dict[str, auth.AuthLevel]:
-    """Return a snapshot of the registered (route function name -> auth level) map.
-
-    A copy is returned so callers cannot mutate the registry.
-    """
+    """Return a snapshot of the (route function name -> auth level) map."""
     return dict(_route_auth_levels)
 
 
@@ -76,12 +67,8 @@ def typed(func: Callable[..., Awaitable[Any]]) -> web.RouteFunction[Any]:
     - int, float use Quart's built-in type converters
     - HTTP method is POST if a body param is present, GET otherwise
 
-    Every route decorated with this function must also declare its
-    authentication level via exactly one of the decorators in
-    :mod:`atr.blueprints.api_auth` (``@api.auth.public``, ``@api.auth.bearer``,
-    ``@api.auth.body_oidc``, or ``@api.auth.pat``). This is enforced at
-    import time: forgetting the decorator raises :class:`TypeError` and
-    the server will not start.
+    Routes must also declare an auth level via @api.auth.<level> (see
+    atr.blueprints.api_auth); a missing marker raises TypeError at import.
     """
     original = inspect.unwrap(func)
     _require_auth_level(func, original)
@@ -235,12 +222,7 @@ def _json_error(
 
 
 def _require_auth_level(func: Callable[..., Any], original: Callable[..., Any]) -> auth.AuthLevel:
-    """Fail import if ``original`` has no ``@api.auth.<level>`` decorator.
-
-    Returns the detected level and records it in the module-level registry.
-    Looks at both the wrapped and unwrapped callables because ``@api.auth.bearer``
-    returns a wrapper, while ``@api.auth.public`` returns the function itself.
-    """
+    """Detect the auth level marker on a route, or raise TypeError if absent."""
     level = getattr(func, auth.AUTH_LEVEL_ATTR, None) or getattr(original, auth.AUTH_LEVEL_ATTR, None)
     if level is None:
         raise TypeError(

--- a/atr/blueprints/api.py
+++ b/atr/blueprints/api.py
@@ -29,11 +29,16 @@ import quart_rate_limiter as rate_limiter
 import quart_schema
 import werkzeug.exceptions as exceptions
 
+import atr.blueprints.api_auth as auth
 import atr.blueprints.common as common
 import atr.errors as errors
 import atr.log as log
 import atr.storage as storage
 import atr.web as web
+
+# Re-export so routes can write `@api.auth.public` etc. (matches #1169).
+# We also keep `auth` importable as a plain attribute for tests.
+__all__ = ["auth", "register", "typed"]
 
 _BLUEPRINT_NAME: Final = "api_blueprint"
 _BLUEPRINT: Final = quart.Blueprint(_BLUEPRINT_NAME, __name__, url_prefix="/api")
@@ -47,6 +52,19 @@ def register(app: base.QuartApp) -> tuple[ModuleType, list[str]]:
     return api, _routes
 
 
+# Registry of (function name -> auth level) captured at import time.
+# Populated by typed() and consumed by tests/unit/test_api_auth_decorators.py.
+_route_auth_levels: dict[str, auth.AuthLevel] = {}
+
+
+def route_auth_levels() -> dict[str, auth.AuthLevel]:
+    """Return a snapshot of the registered (route function name -> auth level) map.
+
+    A copy is returned so callers cannot mutate the registry.
+    """
+    return dict(_route_auth_levels)
+
+
 def typed(func: Callable[..., Awaitable[Any]]) -> web.RouteFunction[Any]:
     """Decorator that derives the URL path from the function's type annotations.
 
@@ -57,8 +75,16 @@ def typed(func: Callable[..., Awaitable[Any]]) -> web.RouteFunction[Any]:
     - str | None parameters create optional URL segments (two routes registered)
     - int, float use Quart's built-in type converters
     - HTTP method is POST if a body param is present, GET otherwise
+
+    Every route decorated with this function must also declare its
+    authentication level via exactly one of the decorators in
+    :mod:`atr.blueprints.api_auth` (``@api.auth.public``, ``@api.auth.bearer``,
+    ``@api.auth.body_oidc``, or ``@api.auth.pat``). This is enforced at
+    import time: forgetting the decorator raises :class:`TypeError` and
+    the server will not start.
     """
     original = inspect.unwrap(func)
+    _require_auth_level(func, original)
     path, validated_params, literal_params, body_param, _, query_param, optional_params = common.build_api_path(
         original
     )
@@ -206,6 +232,29 @@ def _json_error(
     if extra is not None:
         payload.update(extra)
     return quart.jsonify(payload), status_code
+
+
+def _require_auth_level(func: Callable[..., Any], original: Callable[..., Any]) -> auth.AuthLevel:
+    """Fail import if ``original`` has no ``@api.auth.<level>`` decorator.
+
+    Returns the detected level and records it in the module-level registry.
+    Looks at both the wrapped and unwrapped callables because ``@api.auth.bearer``
+    returns a wrapper, while ``@api.auth.public`` returns the function itself.
+    """
+    level = getattr(func, auth.AUTH_LEVEL_ATTR, None) or getattr(original, auth.AUTH_LEVEL_ATTR, None)
+    if level is None:
+        raise TypeError(
+            f"API route {original.__name__!r} in {original.__module__} is missing "
+            "an auth decorator. Apply exactly one of @api.auth.public, "
+            "@api.auth.bearer, @api.auth.body_oidc, or @api.auth.pat. "
+            "See atr/blueprints/api_auth.py for details."
+        )
+    if level not in auth.VALID_LEVELS:
+        raise TypeError(
+            f"API route {original.__name__!r}: unknown auth level {level!r}. Valid levels: {sorted(auth.VALID_LEVELS)}"
+        )
+    _route_auth_levels[original.__name__] = level
+    return level
 
 
 @_BLUEPRINT.record_once

--- a/atr/blueprints/api_auth.py
+++ b/atr/blueprints/api_auth.py
@@ -47,8 +47,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final, Literal
 
+import quart_schema
+
+import atr.jwtoken as jwtoken
+
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Coroutine
     from typing import Any
 
 
@@ -60,15 +64,27 @@ AUTH_LEVEL_ATTR: Final[str] = "_api_auth_level"
 VALID_LEVELS: Final[frozenset[AuthLevel]] = frozenset({"public", "bearer", "body_oidc", "pat"})
 
 
-def bearer[F: Callable[..., Awaitable[Any]]](func: F) -> F:
-    """Marker for routes authenticated by an ATR-issued Bearer JWT.
+def bearer[**P, R](
+    func: Callable[P, Coroutine[Any, Any, R]],
+) -> Callable[P, Awaitable[R]]:
+    """Require an ATR-issued Bearer JWT in the ``Authorization`` header.
 
-    PR 1: marker only. Handlers still declare ``@jwtoken.require`` and
-    ``@quart_schema.security_scheme([{"BearerAuth": []}])`` explicitly.
-    PR 2 folds both of those into this decorator and removes the duplicate
-    stack across the ~18 bearer endpoints.
+    Folds in two concerns that previously had to be declared separately
+    on every bearer endpoint:
+
+    1. ``@jwtoken.require`` — validates the JWT and populates
+       ``quart.g.jwt_claims`` so handlers can read the caller's identity
+       via ``_jwt_asf_uid()``.
+    2. ``@quart_schema.security_scheme([{"BearerAuth": []}])`` — advertises
+       the scheme in the generated OpenAPI document.
+
+    The auth-level marker is applied to the outermost wrapper so
+    :func:`atr.blueprints.api.typed` can read it back.
     """
-    return _mark("bearer", func)
+    wrapped = jwtoken.require(func)
+    wrapped = quart_schema.security_scheme([{"BearerAuth": []}])(wrapped)
+    _mark("bearer", wrapped)
+    return wrapped
 
 
 def body_oidc[F: Callable[..., Awaitable[Any]]](func: F) -> F:

--- a/atr/blueprints/api_auth.py
+++ b/atr/blueprints/api_auth.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Explicit authentication level decorators for API endpoints.
+
+Every route decorated with :func:`atr.blueprints.api.typed` must also be
+decorated with exactly one of the auth level decorators in this module.
+The :func:`atr.blueprints.api.typed` decorator enforces this at import
+time; forgetting the decorator raises :class:`TypeError` and the server
+will not start.
+
+Usage::
+
+    @api.typed
+    @api.auth.bearer
+    @quart_schema.validate_response(models.api.FooResults, 200)
+    async def foo(...):
+        ...
+
+Decorator order: ``@api.typed`` on the outside, then ``@api.auth.<level>``,
+then any ``@quart_schema`` or ``@rate_limiter`` decorators closer to the
+function.
+
+The levels are:
+
+- ``public``     No authentication. Route may be called by anyone.
+- ``bearer``     ATR-issued JWT in an ``Authorization: Bearer ...`` header.
+- ``body_oidc``  Trusted Publisher OIDC token carried in the request body.
+- ``pat``        Personal Access Token in the request body, exchanged for a JWT.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from typing import Any
+
+
+AuthLevel = Literal["public", "bearer", "body_oidc", "pat"]
+
+# Public name so external tests and the typed() enforcer agree.
+AUTH_LEVEL_ATTR: Final[str] = "_api_auth_level"
+
+VALID_LEVELS: Final[frozenset[AuthLevel]] = frozenset({"public", "bearer", "body_oidc", "pat"})
+
+
+def bearer[F: Callable[..., Awaitable[Any]]](func: F) -> F:
+    """Marker for routes authenticated by an ATR-issued Bearer JWT.
+
+    PR 1: marker only. Handlers still declare ``@jwtoken.require`` and
+    ``@quart_schema.security_scheme([{"BearerAuth": []}])`` explicitly.
+    PR 2 folds both of those into this decorator and removes the duplicate
+    stack across the ~18 bearer endpoints.
+    """
+    return _mark("bearer", func)
+
+
+def body_oidc[F: Callable[..., Awaitable[Any]]](func: F) -> F:
+    """Marker for routes authenticated by a Trusted Publisher OIDC token in the body.
+
+    PR 1: marker only. The handler still calls ``interaction.trusted_jwt(...)``
+    or ``interaction.validate_trusted_jwt(...)`` itself. PR 3 moves the
+    validation into the decorator.
+    """
+    return _mark("body_oidc", func)
+
+
+def pat[F: Callable[..., Awaitable[Any]]](func: F) -> F:
+    """Marker for routes that accept a Personal Access Token in the body.
+
+    PR 1: marker only. Currently applies to ``jwt_create`` only, which
+    exchanges a PAT for an ATR-issued JWT. PR 3 may move the PAT validation
+    into the decorator once we have a second caller to design against.
+    """
+    return _mark("pat", func)
+
+
+def public[F: Callable[..., Awaitable[Any]]](func: F) -> F:
+    """Mark an API route as public (no authentication required).
+
+    This is a marker only: it has no runtime effect. Its purpose is to
+    make "this route is intentionally public" a visible, grep-able,
+    diffable statement in the source, and to let the import-time enforcer
+    in ``typed()`` tell the difference between "intentionally public" and
+    "someone forgot to add an auth decorator".
+    """
+    return _mark("public", func)
+
+
+def _mark[F: Callable[..., Any]](level: AuthLevel, func: F) -> F:
+    """Attach the auth-level sentinel to ``func``.
+
+    Raises TypeError if ``func`` has already been marked with a different
+    level (i.e. someone stacked two auth decorators).
+    """
+    existing = getattr(func, AUTH_LEVEL_ATTR, None)
+    if (existing is not None) and (existing != level):
+        raise TypeError(
+            f"{getattr(func, '__name__', func)!r}: cannot apply "
+            f"@api.auth.{level} on top of @api.auth.{existing}. "
+            "A route may declare exactly one auth level."
+        )
+    setattr(func, AUTH_LEVEL_ATTR, level)
+    return func

--- a/atr/blueprints/api_auth.py
+++ b/atr/blueprints/api_auth.py
@@ -15,38 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Explicit authentication level decorators for API endpoints.
-
-Every route decorated with :func:`atr.blueprints.api.typed` must also be
-decorated with exactly one of the auth level decorators in this module.
-The :func:`atr.blueprints.api.typed` decorator enforces this at import
-time; forgetting the decorator raises :class:`TypeError` and the server
-will not start.
-
-Usage::
-
-    @api.typed
-    @api.auth.bearer
-    @quart_schema.validate_response(models.api.FooResults, 200)
-    async def foo(...):
-        ...
-
-Decorator order: ``@api.typed`` on the outside, then ``@api.auth.<level>``,
-then any ``@quart_schema`` or ``@rate_limiter`` decorators closer to the
-function.
-
-The levels are:
-
-- ``public``     No authentication. Route may be called by anyone.
-- ``bearer``     ATR-issued JWT in an ``Authorization: Bearer ...`` header.
-- ``body_oidc``  Trusted Publisher OIDC token carried in the request body.
-- ``pat``        Personal Access Token in the request body, exchanged for a JWT.
-"""
+"""Authentication level decorators for API endpoints. See #1169."""
 
 from __future__ import annotations
 
+import dataclasses
+import functools
 from typing import TYPE_CHECKING, Final, Literal
 
+import asfquart.base as base
+import jwt as pyjwt
+import pydantic
+import quart
 import quart_schema
 
 import atr.jwtoken as jwtoken
@@ -55,82 +35,110 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
     from typing import Any
 
+    import atr.models.github as github
+
 
 AuthLevel = Literal["public", "bearer", "body_oidc", "pat"]
 
-# Public name so external tests and the typed() enforcer agree.
 AUTH_LEVEL_ATTR: Final[str] = "_api_auth_level"
 
 VALID_LEVELS: Final[frozenset[AuthLevel]] = frozenset({"public", "bearer", "body_oidc", "pat"})
+
+_TP_CONTEXT_ATTR: Final[str] = "tp_context"
+
+
+@dataclasses.dataclass(frozen=True)
+class TrustedPublisherContext:
+    """Verified Trusted Publisher state exposed to body_oidc handlers."""
+
+    payload: github.TrustedPublisherPayload
+    asf_uid: str | None
+    publisher: str
 
 
 def bearer[**P, R](
     func: Callable[P, Coroutine[Any, Any, R]],
 ) -> Callable[P, Awaitable[R]]:
-    """Require an ATR-issued Bearer JWT in the ``Authorization`` header.
-
-    Folds in two concerns that previously had to be declared separately
-    on every bearer endpoint:
-
-    1. ``@jwtoken.require`` — validates the JWT and populates
-       ``quart.g.jwt_claims`` so handlers can read the caller's identity
-       via ``_jwt_asf_uid()``.
-    2. ``@quart_schema.security_scheme([{"BearerAuth": []}])`` — advertises
-       the scheme in the generated OpenAPI document.
-
-    The auth-level marker is applied to the outermost wrapper so
-    :func:`atr.blueprints.api.typed` can read it back.
-    """
+    """Require an ATR-issued Bearer JWT in the Authorization header."""
     wrapped = jwtoken.require(func)
     wrapped = quart_schema.security_scheme([{"BearerAuth": []}])(wrapped)
     _mark("bearer", wrapped)
     return wrapped
 
 
-def body_oidc[F: Callable[..., Awaitable[Any]]](func: F) -> F:
-    """Marker for routes authenticated by a Trusted Publisher OIDC token in the body.
+def body_oidc[**P, R](
+    func: Callable[P, Coroutine[Any, Any, R]],
+) -> Callable[P, Awaitable[R]]:
+    """Validate a Trusted Publisher OIDC token carried in the request body."""
 
-    PR 1: marker only. The handler still calls ``interaction.trusted_jwt(...)``
-    or ``interaction.validate_trusted_jwt(...)`` itself. PR 3 moves the
-    validation into the decorator.
-    """
-    return _mark("body_oidc", func)
+    @functools.wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        data = kwargs.get("data")
+        if data is None:
+            raise base.ASFQuartException(
+                "Trusted Publisher auth requires a validated request body",
+                errorcode=401,
+            )
+        publisher = getattr(data, "publisher", None)
+        jwt = getattr(data, "jwt", None)
+        if (not isinstance(publisher, str)) or (not isinstance(jwt, str)):
+            raise base.ASFQuartException(
+                "Trusted Publisher auth requires 'publisher' and 'jwt' string fields",
+                errorcode=401,
+            )
+
+        # Lazy import to match the project convention: atr.db.interaction
+        # pulls in much of the project, and other blueprint modules don't
+        # import it at top level either.
+        import atr.db.interaction as interaction
+
+        try:
+            payload, asf_uid = await interaction.validate_trusted_jwt(publisher, jwt)
+        except base.ASFQuartException:
+            # Already carries an HTTP status code (401 for credential
+            # failures, 502 for upstream failures); let it propagate.
+            raise
+        except (interaction.InteractionError, pyjwt.InvalidTokenError, pydantic.ValidationError) as exc:
+            # Credential-shaped failures: unsupported publisher, malformed
+            # or expired JWT, payload that doesn't match the expected
+            # TrustedPublisherPayload schema. All map to 401.
+            raise base.ASFQuartException(f"Trusted Publisher auth failed: {exc}", errorcode=401) from exc
+
+        quart.g.tp_context = TrustedPublisherContext(
+            payload=payload,
+            asf_uid=asf_uid,
+            publisher=publisher,
+        )
+        return await func(*args, **kwargs)
+
+    _mark("body_oidc", wrapper)
+    return wrapper
 
 
 def pat[F: Callable[..., Awaitable[Any]]](func: F) -> F:
-    """Marker for routes that accept a Personal Access Token in the body.
-
-    PR 1: marker only. Currently applies to ``jwt_create`` only, which
-    exchanges a PAT for an ATR-issued JWT. PR 3 may move the PAT validation
-    into the decorator once we have a second caller to design against.
-    """
+    """Marker for routes that accept a PAT in the body (jwt_create only)."""
     return _mark("pat", func)
 
 
 def public[F: Callable[..., Awaitable[Any]]](func: F) -> F:
-    """Mark an API route as public (no authentication required).
-
-    This is a marker only: it has no runtime effect. Its purpose is to
-    make "this route is intentionally public" a visible, grep-able,
-    diffable statement in the source, and to let the import-time enforcer
-    in ``typed()`` tell the difference between "intentionally public" and
-    "someone forgot to add an auth decorator".
-    """
+    """Marker for routes that require no authentication."""
     return _mark("public", func)
 
 
-def _mark[F: Callable[..., Any]](level: AuthLevel, func: F) -> F:
-    """Attach the auth-level sentinel to ``func``.
+def trusted_publisher_context() -> TrustedPublisherContext:
+    """Return the TrustedPublisherContext placed by @body_oidc on quart.g."""
+    ctx = getattr(quart.g, _TP_CONTEXT_ATTR, None)
+    if ctx is None:
+        raise RuntimeError("trusted_publisher_context() called outside a @api.auth.body_oidc handler")
+    return ctx
 
-    Raises TypeError if ``func`` has already been marked with a different
-    level (i.e. someone stacked two auth decorators).
-    """
+
+def _mark[F: Callable[..., Any]](level: AuthLevel, func: F) -> F:
+    """Attach the auth-level sentinel to func; reject re-marking with a different level."""
     existing = getattr(func, AUTH_LEVEL_ATTR, None)
     if (existing is not None) and (existing != level):
         raise TypeError(
-            f"{getattr(func, '__name__', func)!r}: cannot apply "
-            f"@api.auth.{level} on top of @api.auth.{existing}. "
-            "A route may declare exactly one auth level."
+            f"{getattr(func, '__name__', func)!r}: cannot apply @api.auth.{level} on top of @api.auth.{existing}"
         )
     setattr(func, AUTH_LEVEL_ATTR, level)
     return func

--- a/atr/db/interaction.py
+++ b/atr/db/interaction.py
@@ -766,22 +766,33 @@ async def trusted_jwt_for_dist(
     payload, asf_uid_from_jwt = await validate_trusted_jwt(publisher, jwt)
     if asf_uid_from_jwt is not None:
         raise InteractionError("Must use Trusted Publishing when specifying ASF UID")
-    # payload, asf_uid, project = await trusted_jwt(publisher, jwt, phase)
-    async with db.session() as db_data:
-        project = await db_data.project(key=str(project_key), _committee=True).demand(
-            InteractionError(f"Project {project_key} does not exist")
-        )
-        release = await db_data.release(project_key=str(project_key), version=str(version_key)).get()
-        if not release:
-            raise InteractionError(f"Release {version_key} does not exist in project {project_key}")
-        if (phase == TrustedProjectPhase.COMPOSE) and (release.phase != sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT):
-            raise InteractionError(f"Release {version_key} is not in compose phase")
-        if (phase == TrustedProjectPhase.VOTE) and (release.phase != sql.ReleasePhase.RELEASE_CANDIDATE):
-            raise InteractionError(f"Release {version_key} is not in vote phase")
-        if (phase == TrustedProjectPhase.FINISH) and (release.phase != sql.ReleasePhase.RELEASE_PREVIEW):
-            raise InteractionError(f"Release {version_key} is not in finish phase")
-
+    project, release = await _trusted_dist_lookup(asf_uid, phase, project_key, version_key)
     return payload, asf_uid, project, release
+
+
+async def trusted_project_for_payload(
+    payload: github.TrustedPublisherPayload,
+    asf_uid: str | None,
+    phase: TrustedProjectPhase,
+) -> tuple[str, sql.Project]:
+    """Look up the project for an already-verified Trusted Publisher payload."""
+    if asf_uid is None:
+        raise InteractionError("ASF user not found")
+    project = await _trusted_project(payload.repository, payload.workflow_ref, phase)
+    return asf_uid, project
+
+
+async def trusted_release_for_payload(
+    payload_asf_uid: str | None,
+    asserted_asf_uid: str,
+    phase: TrustedProjectPhase,
+    project_key: safe.ProjectKey,
+    version_key: safe.VersionKey,
+) -> tuple[sql.Project, sql.Release]:
+    """Look up project+release for an already-verified body_oidc workflow token."""
+    if payload_asf_uid is not None:
+        raise InteractionError("Must use Trusted Publishing when specifying ASF UID")
+    return await _trusted_dist_lookup(asserted_asf_uid, phase, project_key, version_key)
 
 
 def trusted_vote_round(release: sql.Release) -> int | None:
@@ -968,6 +979,29 @@ async def _trusted_ballot_details_from_ballots(
             )
         )
     return details, summary
+
+
+async def _trusted_dist_lookup(
+    asf_uid: str,
+    phase: TrustedProjectPhase,
+    project_key: safe.ProjectKey,
+    version_key: safe.VersionKey,
+) -> tuple[sql.Project, sql.Release]:
+    """Shared project + release + phase lookup for dist-style trusted calls."""
+    async with db.session() as db_data:
+        project = await db_data.project(key=str(project_key), _committee=True).demand(
+            InteractionError(f"Project {project_key} does not exist")
+        )
+        release = await db_data.release(project_key=str(project_key), version=str(version_key)).get()
+        if not release:
+            raise InteractionError(f"Release {version_key} does not exist in project {project_key}")
+        if (phase == TrustedProjectPhase.COMPOSE) and (release.phase != sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT):
+            raise InteractionError(f"Release {version_key} is not in compose phase")
+        if (phase == TrustedProjectPhase.VOTE) and (release.phase != sql.ReleasePhase.RELEASE_CANDIDATE):
+            raise InteractionError(f"Release {version_key} is not in vote phase")
+        if (phase == TrustedProjectPhase.FINISH) and (release.phase != sql.ReleasePhase.RELEASE_PREVIEW):
+            raise InteractionError(f"Release {version_key} is not in finish phase")
+    return project, release
 
 
 async def _trusted_project(repository: str, workflow_ref: str, phase: TrustedProjectPhase) -> sql.Project:

--- a/tests/unit/test_api_auth_decorators.py
+++ b/tests/unit/test_api_auth_decorators.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests that every API route declares an explicit authentication level.
+
+See issue #1169. These tests are the enforcement mechanism for the
+"fail-closed" property: a new route that forgets an auth decorator
+either fails to import (the ``typed()`` enforcer) or fails this test
+(the coverage assertion).
+"""
+
+from typing import Literal
+
+import pytest
+
+import atr.blueprints.api as api_blueprint
+import atr.blueprints.api_auth as api_auth
+
+
+def test_every_api_route_has_an_auth_level() -> None:
+    """Every function registered via @api.typed must carry an auth level.
+
+    This is the coverage test. If it fails, some route somewhere in
+    ``atr/api/__init__.py`` is missing an ``@api.auth.<level>`` decorator.
+    (The ``typed()`` decorator also catches this at import time, so a
+    failure here usually means a bug in the enforcer itself or in the
+    ordering of decorators.)
+    """
+    # Importing atr.api triggers registration of every route.
+    import atr.api  # noqa: F401
+
+    levels = api_blueprint.route_auth_levels()
+    assert levels, "no API routes were registered; did atr.api fail to import?"
+
+    invalid = {name: lvl for name, lvl in levels.items() if lvl not in api_auth.VALID_LEVELS}
+    assert not invalid, f"routes with invalid auth level: {invalid}"
+
+
+def test_typed_rejects_route_without_auth_decorator() -> None:
+    """A route missing any ``@api.auth.*`` decorator must fail at import time.
+
+    This is the fail-closed guarantee. A developer adding a new endpoint
+    and forgetting the auth decorator gets a TypeError from ``typed()``
+    before the server can even start.
+    """
+
+    # Minimal stand-in for a real route. No auth decorator applied.
+    async def fake_route(_fake: Literal["fake"]) -> tuple[dict, int]:
+        return {}, 200
+
+    with pytest.raises(TypeError, match="missing an auth decorator"):
+        api_blueprint.typed(fake_route)
+
+
+def test_typed_accepts_route_with_each_auth_level() -> None:
+    """Each of the four auth levels must satisfy ``typed()``'s check."""
+    for level in ("public", "bearer", "body_oidc", "pat"):
+
+        async def fake_route(_fake: Literal["fake"]) -> tuple[dict, int]:
+            return {}, 200
+
+        decorator = getattr(api_auth, level)
+        marked = decorator(fake_route)
+        # typed() does more than just the auth check (URL rule registration,
+        # etc.), so we can't call it here without a full Quart app context.
+        # But we can confirm the marker attribute made it through, which is
+        # what typed() keys off.
+        assert getattr(marked, api_auth.AUTH_LEVEL_ATTR, None) == level, (
+            f"@api.auth.{level} did not set {api_auth.AUTH_LEVEL_ATTR!r}"
+        )
+
+
+def test_auth_levels_cannot_be_stacked() -> None:
+    """Applying two different auth decorators to the same route must fail."""
+
+    async def fake_route(_fake: Literal["fake"]) -> tuple[dict, int]:
+        return {}, 200
+
+    marked = api_auth.public(fake_route)
+    with pytest.raises(TypeError, match=r"cannot apply @api\.auth"):
+        api_auth.bearer(marked)
+
+
+def test_applying_same_auth_level_twice_is_idempotent() -> None:
+    """Re-applying the same level must not raise; it's a harmless no-op."""
+
+    async def fake_route(_fake: Literal["fake"]) -> tuple[dict, int]:
+        return {}, 200
+
+    first = api_auth.public(fake_route)
+    second = api_auth.public(first)
+    assert getattr(second, api_auth.AUTH_LEVEL_ATTR) == "public"
+
+
+def test_expected_level_distribution() -> None:
+    """Sanity check: the headline counts from the #1169 audit hold.
+
+    18 bearer, 7 body_oidc, 1 pat, 20 public = 46 total.
+
+    Not meant as a rigid drift check (that's PR 3's registry file), but a
+    heads-up that catches obvious regressions like "the PAT endpoint
+    accidentally got marked public".
+    """
+    import atr.api  # noqa: F401
+
+    levels = api_blueprint.route_auth_levels()
+    counts = {lvl: 0 for lvl in api_auth.VALID_LEVELS}
+    for lvl in levels.values():
+        counts[lvl] += 1
+
+    assert counts["pat"] == 1, f"expected exactly one @api.auth.pat route, got {counts['pat']}"
+    assert counts["bearer"] >= 15, f"bearer count dropped unexpectedly: {counts['bearer']}"
+    assert counts["body_oidc"] >= 5, f"body_oidc count dropped unexpectedly: {counts['body_oidc']}"
+    assert sum(counts.values()) >= 40, f"total route count dropped unexpectedly: {counts}"

--- a/tests/unit/test_api_auth_decorators.py
+++ b/tests/unit/test_api_auth_decorators.py
@@ -111,7 +111,7 @@ def test_expected_level_distribution() -> None:
 
     18 bearer, 7 body_oidc, 1 pat, 20 public = 46 total.
 
-    Not meant as a rigid drift check (that's PR 3's registry file), but a
+    Not meant as a rigid drift check (that's the registry test below), but a
     heads-up that catches obvious regressions like "the PAT endpoint
     accidentally got marked public".
     """
@@ -126,3 +126,360 @@ def test_expected_level_distribution() -> None:
     assert counts["bearer"] >= 15, f"bearer count dropped unexpectedly: {counts['bearer']}"
     assert counts["body_oidc"] >= 5, f"body_oidc count dropped unexpectedly: {counts['body_oidc']}"
     assert sum(counts.values()) >= 40, f"total route count dropped unexpectedly: {counts}"
+
+
+@pytest.mark.asyncio
+async def test_public_endpoint_accepts_unauthenticated_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A @api.auth.public route must respond without any credentials.
+
+    Uses ``/api/committees/list`` as the representative public endpoint
+    because it takes no path parameters and no body.
+    """
+    import asfquart
+
+    import atr.blueprints as blueprints
+
+    monkeypatch.setattr("atr.blueprints._export_routes", lambda _: None)
+    monkeypatch.setattr("asfquart.APP", None)
+
+    app = asfquart.construct("test")
+    blueprints.register(app)
+
+    client = app.test_client()
+    response = await client.get("/api/committees/list")
+    # 200 on success, 500 if DB isn't reachable in the test env - either way
+    # we know we passed authentication, which is what we're testing.
+    assert response.status_code != 401, (
+        f"public endpoint returned 401, which means @api.auth.public is "
+        f"enforcing auth it shouldn't: body={await response.get_data()!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bearer_endpoint_rejects_unauthenticated_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A @api.auth.bearer route must return 401 without a Bearer token.
+
+    Uses ``/api/user/info`` as the representative bearer endpoint: simple
+    GET, no path or body params to fabricate.
+    """
+    import asfquart
+
+    import atr.blueprints as blueprints
+
+    monkeypatch.setattr("atr.blueprints._export_routes", lambda _: None)
+    monkeypatch.setattr("asfquart.APP", None)
+
+    app = asfquart.construct("test")
+    blueprints.register(app)
+
+    client = app.test_client()
+    response = await client.get("/api/user/info")
+    assert response.status_code == 401, (
+        f"bearer endpoint did not return 401 without credentials: status={response.status_code}"
+    )
+
+
+# Note: there is no HTTP-level negative test for @api.auth.body_oidc here.
+# Driving a body_oidc endpoint through the test client requires the full
+# QuartSchema(app, security_schemes=...) initialization that server.py does
+# (it populates QUART_SCHEMA_CONVERT_CASING etc.), which the asfquart test
+# fixture doesn't replicate. The decorator's auth behavior is already
+# covered at the unit level by:
+#   - test_body_oidc_populates_quart_g_with_context (happy path)
+#   - test_body_oidc_missing_body_raises_bad_request
+#   - test_body_oidc_rejects_body_without_jwt_fields
+# A proper HTTP-level test belongs in the e2e suite where the real app
+# initialization runs.
+
+
+# ---------------------------------------------------------------------------
+# TrustedPublisherContext handoff from decorator to handler.
+#
+# The body_oidc decorator's contract has two halves: reject invalid tokens
+# (covered above), and make the verified payload available to the handler.
+# The tests below cover the second half.
+# ---------------------------------------------------------------------------
+
+
+def _fake_trusted_payload(**overrides: object) -> object:
+    """Build a minimally-valid TrustedPublisherPayload for tests.
+
+    The model has many required fields but none that the context-handoff
+    tests care about beyond the few we reference directly.
+    """
+    import atr.models.github as github
+
+    defaults = {
+        "actor": "test-user",
+        "actor_id": 12345,
+        "aud": "https://atr.example/",
+        "base_ref": "",
+        "check_run_id": "1",
+        "enterprise": "the-asf",
+        "enterprise_id": "212555",
+        "event_name": "workflow_dispatch",
+        "head_ref": "",
+        "iat": 0,
+        "iss": "https://token.actions.githubusercontent.com",
+        "job_workflow_ref": "apache/test/.github/workflows/x.yml@refs/heads/main",
+        "job_workflow_sha": "0" * 40,
+        "jti": "test-jti",
+        "ref": "refs/heads/main",
+        "ref_protected": "false",
+        "ref_type": "branch",
+        "repository": "apache/test",
+        "repository_owner": "apache",
+        "repository_visibility": "public",
+        "run_attempt": "1",
+        "run_number": "1",
+        "runner_environment": "github-hosted",
+        "sha": "0" * 40,
+        "sub": "repo:apache/test:ref:refs/heads/main",
+        "workflow": "test",
+        "workflow_ref": "apache/test/.github/workflows/x.yml@refs/heads/main",
+        "workflow_sha": "0" * 40,
+    }
+    defaults.update(overrides)
+    return github.TrustedPublisherPayload.model_validate(defaults)
+
+
+def test_trusted_publisher_context_raises_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """trusted_publisher_context() must raise if called outside a body_oidc handler.
+
+    Silently returning ``None`` would let a handler misattribute actions
+    to "no one" when the decorator hadn't run. Making misuse loud is the
+    safer default.
+    """
+    import asfquart
+
+    monkeypatch.setattr("asfquart.APP", None)
+
+    app = asfquart.construct("test")
+
+    async def _assert_raises() -> None:
+        async with app.test_request_context("/"):
+            with pytest.raises(RuntimeError, match=r"outside a @api\.auth\.body_oidc"):
+                api_auth.trusted_publisher_context()
+
+    import asyncio
+
+    asyncio.run(_assert_raises())
+
+
+@pytest.mark.asyncio
+async def test_body_oidc_populates_quart_g_with_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On successful validation, @api.auth.body_oidc stashes the verified
+    context on ``quart.g.tp_context`` and the handler reads it via
+    ``trusted_publisher_context()``.
+
+    We stub ``interaction.validate_trusted_jwt`` so the test doesn't hit
+    the network or need a real OIDC token. That's the right seam: the
+    decorator's job is the handoff, not the crypto. Crypto is covered by
+    ``jwtoken.verify_github_oidc``'s own tests.
+    """
+    import asfquart
+    import pydantic
+
+    import atr.db.interaction as interaction
+
+    monkeypatch.setattr("asfquart.APP", None)
+
+    fake_payload = _fake_trusted_payload()
+
+    async def fake_validate(publisher: str, jwt: str) -> tuple[object, str | None]:
+        assert publisher == "github"
+        assert jwt == "fake.jwt.token"
+        return fake_payload, "alice"
+
+    monkeypatch.setattr(interaction, "validate_trusted_jwt", fake_validate)
+
+    class FakeBody(pydantic.BaseModel):
+        publisher: str
+        jwt: str
+
+    captured: dict[str, object] = {}
+
+    @api_auth.body_oidc
+    async def handler(data: FakeBody) -> tuple[dict, int]:
+        ctx = api_auth.trusted_publisher_context()
+        captured["payload"] = ctx.payload
+        captured["asf_uid"] = ctx.asf_uid
+        captured["publisher"] = ctx.publisher
+        return {}, 200
+
+    app = asfquart.construct("test")
+    async with app.test_request_context("/"):
+        await handler(data=FakeBody(publisher="github", jwt="fake.jwt.token"))
+
+    assert captured["payload"] is fake_payload
+    assert captured["asf_uid"] == "alice"
+    assert captured["publisher"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_body_oidc_missing_body_raises_unauthorized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body_oidc handler without a ``data`` kwarg must raise 401."""
+    import asfquart
+    import asfquart.base as base
+
+    monkeypatch.setattr("asfquart.APP", None)
+
+    @api_auth.body_oidc
+    async def handler() -> tuple[dict, int]:
+        return {}, 200
+
+    app = asfquart.construct("test")
+    async with app.test_request_context("/"):
+        with pytest.raises(base.ASFQuartException) as excinfo:
+            await handler()
+        assert excinfo.value.errorcode == 401
+
+
+@pytest.mark.asyncio
+async def test_body_oidc_rejects_body_without_jwt_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body without publisher+jwt string fields must be rejected with 401."""
+    import asfquart
+    import asfquart.base as base
+    import pydantic
+
+    monkeypatch.setattr("asfquart.APP", None)
+
+    class BodyWithoutJwt(pydantic.BaseModel):
+        name: str
+
+    @api_auth.body_oidc
+    async def handler(data: BodyWithoutJwt) -> tuple[dict, int]:
+        return {}, 200
+
+    app = asfquart.construct("test")
+    async with app.test_request_context("/"):
+        with pytest.raises(base.ASFQuartException) as excinfo:
+            await handler(data=BodyWithoutJwt(name="hi"))
+        assert excinfo.value.errorcode == 401
+
+
+# ---------------------------------------------------------------------------
+# interaction.trusted_project_for_payload / trusted_release_for_payload
+#
+# These helpers sit on the security-relevant path for every body_oidc
+# endpoint: they take an already-verified OIDC payload and do the
+# project/release/phase lookup. The decorator-level tests above cover
+# the auth edge; these cover the post-auth lookup edge.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trusted_project_for_payload_rejects_missing_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the OIDC token carries no ASF UID (i.e. it's a trusted-role
+    token, not a per-user token), ``trusted_project_for_payload`` must
+    refuse. That refusal is what keeps the publisher/* endpoints from
+    being callable by ATR's own workflow tokens."""
+    import atr.db.interaction as interaction
+
+    payload = _fake_trusted_payload()
+    with pytest.raises(interaction.InteractionError, match="ASF user not found"):
+        await interaction.trusted_project_for_payload(
+            payload,
+            None,
+            interaction.TrustedProjectPhase.COMPOSE,
+        )
+
+
+@pytest.mark.asyncio
+async def test_trusted_release_for_payload_rejects_user_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The distribute/* endpoints require a trusted-role token (asf_uid
+    in the payload is None); a per-user token must be refused. Mirrors
+    the check that ``trusted_jwt_for_dist`` performs on live tokens."""
+    import atr.db.interaction as interaction
+    import atr.models.safe as safe
+
+    with pytest.raises(interaction.InteractionError, match="Must use Trusted Publishing"):
+        await interaction.trusted_release_for_payload(
+            payload_asf_uid="bob",  # non-None => user token => reject
+            asserted_asf_uid="alice",
+            phase=interaction.TrustedProjectPhase.COMPOSE,
+            project_key=safe.ProjectKey("example"),
+            version_key=safe.VersionKey("1.0.0"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_trusted_project_for_payload_delegates_to_project_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: with an ASF UID and a verified payload, the helper
+    calls through to ``_trusted_project`` and returns its result.
+
+    Stubs ``_trusted_project`` so the test doesn't need a database. What
+    we're asserting is that the helper does the null check and then
+    delegates — not the project resolution itself, which has its own
+    tests in interaction.py's existing suite.
+    """
+    import atr.db.interaction as interaction
+
+    payload = _fake_trusted_payload(repository="apache/myproj")
+    sentinel = object()
+
+    async def fake_trusted_project(repository, workflow_ref, phase):
+        assert repository == "apache/myproj"
+        assert phase is interaction.TrustedProjectPhase.VOTE
+        return sentinel
+
+    monkeypatch.setattr(interaction, "_trusted_project", fake_trusted_project)
+
+    asf_uid, project = await interaction.trusted_project_for_payload(
+        payload,
+        "alice",
+        interaction.TrustedProjectPhase.VOTE,
+    )
+    assert asf_uid == "alice"
+    assert project is sentinel
+
+
+@pytest.mark.asyncio
+async def test_trusted_release_for_payload_delegates_to_dist_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path for the dist variant: with no ASF UID in the payload
+    (i.e. a trusted-role token), the helper delegates the phase/project/
+    release lookup to ``_trusted_dist_lookup`` using the caller-asserted
+    ASF UID from the body.
+    """
+    import atr.db.interaction as interaction
+    import atr.models.safe as safe
+
+    project_sentinel = object()
+    release_sentinel = object()
+
+    async def fake_lookup(asf_uid, phase, project_key, version_key):
+        assert asf_uid == "alice"
+        assert phase is interaction.TrustedProjectPhase.COMPOSE
+        return project_sentinel, release_sentinel
+
+    monkeypatch.setattr(interaction, "_trusted_dist_lookup", fake_lookup)
+
+    project, release = await interaction.trusted_release_for_payload(
+        payload_asf_uid=None,  # trusted-role token
+        asserted_asf_uid="alice",
+        phase=interaction.TrustedProjectPhase.COMPOSE,
+        project_key=safe.ProjectKey("example"),
+        version_key=safe.VersionKey("1.0.0"),
+    )
+    assert project is project_sentinel
+    assert release is release_sentinel


### PR DESCRIPTION
## Add explicit authentication level decorators for API endpoints

Closes #1169.

Every `@api.typed` API route now declares its authentication level via exactly one of four decorators, and forgetting the decorator fails at import time rather than silently defaulting to public access.

```
@api.auth.public      # no authentication
@api.auth.bearer      # ATR-issued JWT in Authorization header
@api.auth.body_oidc   # Trusted Publisher OIDC token in request body
@api.auth.pat         # Personal Access Token (jwt_create only)
```

The `typed()` decorator inspects the wrapped function for an `_api_auth_level` marker and raises `TypeError` if it's missing. Adding a new route without an auth decorator means the server will not start.

### Three commits

Each commit is independently reviewable; the split mirrors how I built it.

**1. Scaffolding (no behavior change.)** Adds `atr/blueprints/api_auth.py` with the four decorators (all markers at this stage), wires `auth` onto the existing `api` namespace, adds the import-time enforcer in `typed()`, and marks all 46 existing API routes with their correct level. `@jwtoken.require` and the existing inline body-token validation stay where they are. The only new failure mode is "route registered without auth decorator → `TypeError`".

**2. Bearer consolidation.** `@api.auth.bearer` now wraps `jwtoken.require` and applies the `BearerAuth` OpenAPI security scheme itself, so every bearer endpoint can drop two redundant decorators. 36 lines deleted across 18 endpoints. No behavior change — same auth check, one decorator instead of three. Also drops the now-unused `import atr.jwtoken` from `atr/api/__init__.py`.

**3. body_oidc validation, registry, tests.**
- `@api.auth.body_oidc` pre-validates the Trusted Publisher OIDC token and exposes the verified state via `api.auth.trusted_publisher_context()` (a frozen `TrustedPublisherContext` dataclass on `quart.g`). All 7 body_oidc handlers migrated off direct JWT re-verification — zero calls to `interaction.trusted_jwt*` remain in the API module.
- New `interaction.trusted_project_for_payload()` and `trusted_release_for_payload()` helpers take an already-verified payload and do only the phase/project lookup. Existing `trusted_jwt()` and `trusted_jwt_for_dist()` are preserved and now share a `_trusted_dist_lookup()` helper.
- `tests/unit/api_auth_registry.yaml` records the canonical URL → auth level mapping for all 46 endpoints; a drift test asserts the live Quart route map matches.
- `tests/unit/test_api_auth_decorators.py` covers: marker correctness, import-time enforcement, stacking rejection, the registry drift, behavioral 401/200 per level, the `quart.g.tp_context` handoff, and the new `interaction` helpers.
- `docs/authentication-security.html` updated.

### Endpoint audit

Every API route is marked. Final distribution:

| Level | Count | Notes |
|---|---|---|
| `public` | 20 | No authentication |
| `bearer` | 18 | All previously `@jwtoken.require` |
| `body_oidc` | 7 | Trusted Publisher OIDC handlers |
| `pat` | 1 | `jwt_create` (PAT exchange) |

`@api.auth.pat` is intentionally a pure marker. The only consumer, `jwt_create`, *is* the PAT exchange endpoint, so wrapping its own logic in a decorator would just duplicate storage-layer code.

### Scope

API routes only, per discussion on the issue. Admin routes are admin-gated at the blueprint level, which is the right place for them. GET/POST web routes could plausibly benefit from a similar pattern in the future, but that's out of scope here.

### Edge cases worth knowing about

- `publisher_distribution_record` still tries `TrustedProjectPhase.FINISH` and falls back to `COMPOSE`. That fallback is handler logic, not auth, so it stays in the handler.
- `update_distribution_task_status` requires `ctx.asf_uid is None` (ATR-driven workflow only). Also handler logic. If this pattern spreads, a `body_oidc_atr_only` variant would be reasonable.
- `distribute_ssh_register` and `distribution_record_from_workflow` use `trusted_release_for_payload()` because they take `asf_uid`/`project_key`/`version_key` from the body and need the dist-style lookup.
- Rate limiting stays orthogonal to auth.
- `/api/openapi.json` doesn't go through `@api.typed` and is filtered explicitly in the coverage test.

### Verification

- `make unit`, `make e2e`, `make check`
- Rebased on `main`