### PR TITLE
Drop dsa_bits reference; rpgp-py 0.19.7 doesn't expose it

### DIFF
--- a/atr/storage/writers/keys.py
+++ b/atr/storage/writers/keys.py
@@ -133,16 +133,19 @@ def _key_length(key: openpgp.PublicKey) -> int:
     rsa_bits = public_params.rsa_bits
     if isinstance(rsa_bits, int):
         return rsa_bits
-    dsa_bits = public_params.dsa_bits
-    if isinstance(dsa_bits, int):
-        return dsa_bits
     curve_bits = public_params.curve_bits
     if isinstance(curve_bits, int):
         return curve_bits
-    raise ValueError(
-        f"Key size is not available for algorithm {key.public_key_algorithm}:"
-        f" rsa_bits={rsa_bits!r}, dsa_bits={dsa_bits!r}, curve_bits={curve_bits!r}"
-    )
+    # rpgp-py 0.19.7's PublicParamsInfo does not expose a bit-length
+    # field for DSA keys: kind == "dsa" but rsa_bits, curve_bits, and
+    # secret_key_length are all None. Until rpgp-py exposes the DSA
+    # parameter size we cannot validate the key size for DSA keys.
+    if public_params.kind == "dsa":
+        raise ValueError(
+            f"DSA key bit-length is not currently retrievable via rpgp-py "
+            f"({key.public_key_algorithm}); see TODO upstream issue"
+        )
+    raise ValueError(f"Key size is not available for algorithm {key.public_key_algorithm}")
 
 
 def _key_expires_at(key: openpgp.PublicKey) -> datetime.datetime | None:


### PR DESCRIPTION
`make check` fails pyright on main with reportAttributeAccessIssue for PublicParamsInfo.dsa_bits, added in 9cc1dbbe (Restore support for DSA keys). rpgp-py 0.19.7 has no dsa_bits attribute and no equivalent field; for a DSA key, all numeric fields on PublicParamsInfo return None, only kind == dsa identifies it.

DSA keys now raise a clear ValueError instead of AttributeError. RSA and ECC unaffected. Restoring DSA bit-length validation needs upstream work in rpgp-py.

## Testing

`make check` passes

## Rebase info

```
$ git fetch upstream main
From github.com:apache/tooling-trusted-releases
 * branch              main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch fix-keys-dsa-bits is up to date.
```