### PR TITLE
#921 - add endpoint to create/update project data

### DIFF
--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -858,6 +858,39 @@ async def policy_update(
 
 
 @api.typed
+@jwtoken.require
+@quart_schema.security_scheme([{"BearerAuth": []}])
+@quart_schema.validate_response(models.api.ProjectConfigResults, 200)
+async def project_config_upsert(
+    _project_config: Literal["project/config"],
+    data: models.api.ProjectConfigArgs,
+) -> DictResponse:
+    """
+    URL: POST /project/config
+
+    Upsert a project's full configuration.
+
+    Creates a project if it on by the specified key does not yet exist.
+    Otherwise, updates all specified fields for an existing project.
+    The caller must be a committee member of the specified committee,
+    and for an existing project committee_key must match the current value.
+    """
+    asf_uid = _jwt_asf_uid()
+    try:
+        async with storage.write_as_committee_member(str(data.committee_key), asf_uid) as wacm:
+            created = await wacm.project.upsert_config(data)
+    except storage.AccessError as e:
+        raise _http_exception_from_storage_access_error(e) from e
+    except ValueError as e:
+        raise exceptions.BadRequest(str(e))
+    return models.api.ProjectConfigResults(
+        endpoint="/project/config",
+        success=True,
+        created=created,
+    ).model_dump(mode="json"), 200
+
+
+@api.typed
 @quart_schema.validate_response(models.api.ProjectGetResults, 200)
 async def project_get(
     _project_get: Literal["project/get"],

--- a/atr/blueprints/api.py
+++ b/atr/blueprints/api.py
@@ -181,7 +181,7 @@ async def _handle_request_validation(err: quart_schema.RequestSchemaValidationEr
     if not isinstance(err.validation_error, pydantic.ValidationError):
         raise err.validation_error
     verr: pydantic.ValidationError = err.validation_error
-    return _json_error("Input validation failed", 400, {"validation_details": verr.errors()})
+    return _json_error("Input validation failed", 400, {"validation_details": verr.errors(include_context=False)})
 
 
 @_BLUEPRINT.errorhandler(storage.AccessError)

--- a/atr/cycles.py
+++ b/atr/cycles.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Final
 
+import atr.models.sql as sql
+
 if TYPE_CHECKING:
-    import atr.models.sql as sql
+    import atr.db as db
 
 _DEFAULT_CYCLE: Final[str] = "default"
 
@@ -59,3 +61,31 @@ def cycle_name_for_version(project: sql.Project, version: str) -> str:
         raise ValueError(f"cycle_match for project {project.key!r} captured empty string from version {version!r}")
 
     return cycle
+
+
+async def reassign_release_cycles(data: db.Session, project: sql.Project) -> None:
+    """Re-resolve cycle membership for every release in the project.
+
+    Releases whose version doesn't match the current `cycle_match` fall
+    back to the default cycle. New cycles get auto-created in the same
+    transaction.
+    """
+    releases = await data.release(project_key=str(project.key)).all()
+    for release in releases:
+        try:
+            cycle_name = cycle_name_for_version(project, release.version)
+        except ValueError:
+            cycle_name = _DEFAULT_CYCLE
+        new_cycle_key = f"{project.key}-{cycle_name}"
+        if release.cycle_key == new_cycle_key:
+            continue
+        if not await data.project_cycle(cycle_key=new_cycle_key).get():
+            data.add(
+                sql.ProjectCycle(
+                    cycle_key=new_cycle_key,
+                    cycle=cycle_name,
+                    project_key=project.key,
+                    lts=False,
+                )
+            )
+        release.cycle_key = new_cycle_key

--- a/atr/datasources/apache.py
+++ b/atr/datasources/apache.py
@@ -41,6 +41,7 @@ import atr.util as util
 _WHIMSY_COMMITTEE_INFO_URL: Final[str] = "https://whimsy.apache.org/public/committee-info.json"
 _WHIMSY_COMMITTEE_RETIRED_URL: Final[str] = "https://whimsy.apache.org/public/committee-retired.json"
 _WHIMSY_PROJECTS_URL: Final[str] = "https://whimsy.apache.org/public/public_ldap_projects.json"
+_PROJECTS_COMMITTEE_URL: Final[str] = "https://projects.apache.org/json/foundation/committees.json"
 _PROJECTS_PROJECTS_URL: Final[str] = "https://projects.apache.org/json/foundation/projects.json"
 _PROJECTS_PODLINGS_URL: Final[str] = "https://projects.apache.org/json/foundation/podlings.json"
 _PROJECTS_GROUPS_URL: Final[str] = "https://projects.apache.org/json/foundation/groups.json"
@@ -81,6 +82,20 @@ class User(schema.Strict):
 
 
 class Committee(schema.Strict):
+    chair: str
+    charter: str
+    established: str
+    group: str
+    homepage: str
+    id: str
+    name: str
+    rdf: str
+    reporting: int | None = None
+    roster: Annotated[list[User], helpers.DictToList(key="id")]
+    shortdesc: str
+
+
+class WhimsyCommittee(schema.Strict):
     name: str
     display_name: str
     site: str | None
@@ -94,14 +109,14 @@ class Committee(schema.Strict):
     pmc: bool
 
 
-class CommitteeData(schema.Strict):
+class WhimsyCommitteeData(schema.Strict):
     last_updated: str
     committee_count: int
     pmc_count: int
     roster_counts: dict[str, int] = schema.factory(dict)
     officers: dict[str, Any] = schema.factory(dict)
     board: dict[str, Any] = schema.factory(dict)
-    committees: Annotated[list[Committee], helpers.DictToList(key="name")]
+    committees: Annotated[list[WhimsyCommittee], helpers.DictToList(key="name")]
     next_board_meetings: dict[str, Any] = schema.alias_opt("nextBoardMeetings")
 
 
@@ -234,7 +249,18 @@ class ProjectsData(helpers.DictRoot[ProjectStatus]):
     pass
 
 
-async def get_active_committee_data() -> CommitteeData:
+async def get_committee_data() -> dict[str, Committee]:
+    """Returns the list of committees from projects.a.o."""
+
+    async with util.create_secure_session() as session:
+        async with session.get(_PROJECTS_COMMITTEE_URL) as response:
+            response.raise_for_status()
+            data: list = await response.json()
+
+    return {c.get("id"): Committee.model_validate(c) for c in data}
+
+
+async def get_whimsy_committee_data() -> WhimsyCommitteeData:
     """Returns the list of currently active committees."""
 
     async with util.create_secure_session() as session:
@@ -242,7 +268,7 @@ async def get_active_committee_data() -> CommitteeData:
             response.raise_for_status()
             data = await response.json()
 
-    return CommitteeData.model_validate(data)
+    return WhimsyCommitteeData.model_validate(data)
 
 
 async def get_current_podlings_data() -> PodlingsData:
@@ -301,17 +327,18 @@ async def update_metadata() -> tuple[int, int]:
     ldap_projects = await get_ldap_projects_data()
     projects = await get_projects_data()
     podlings_data = await get_current_podlings_data()
-    committees = await get_active_committee_data()
+    whimsy_committees = await get_whimsy_committee_data()
+    committees = await get_committee_data()
 
     ldap_projects_by_name: Mapping[str, LDAPProject] = {p.name: p for p in ldap_projects.projects}
-    committees_by_name: Mapping[str, Committee] = {c.name: c for c in committees.committees}
+    whimsy_committees_by_name: Mapping[str, WhimsyCommittee] = {c.name: c for c in whimsy_committees.committees}
 
     added_count = 0
     updated_count = 0
 
     async with db.session() as data:
         async with data.begin():
-            added, updated = await _update_committees(data, ldap_projects, committees_by_name)
+            added, updated = await _update_committees(data, ldap_projects, whimsy_committees_by_name, committees)
             added_count += added
             updated_count += updated
 
@@ -384,7 +411,10 @@ def _project_status(pmc: sql.Committee, project_key: str, project_status: Projec
 
 
 async def _update_committees(
-    data: db.Session, ldap_projects: LDAPProjectsData, committees_by_name: Mapping[str, Committee]
+    data: db.Session,
+    ldap_projects: LDAPProjectsData,
+    whimsy_committees_by_name: Mapping[str, WhimsyCommittee],
+    committees: dict[str, Committee],
 ) -> tuple[int, int]:
     added_count = 0
     updated_count = 0
@@ -409,9 +439,12 @@ async def _update_committees(
         committee.committers = project.members
         # We create PMCs for now
         committee.is_podling = False
-        committee_info = committees_by_name.get(name)
+        whimsy_info = whimsy_committees_by_name.get(name)
+        if whimsy_info:
+            committee.name = whimsy_info.display_name
+        committee_info = committees.get(name)
         if committee_info:
-            committee.name = committee_info.display_name
+            committee.charter = committee_info.charter
 
         updated_count += 1
 
@@ -473,6 +506,9 @@ async def _update_projects(data: db.Session, projects: ProjectsData) -> tuple[in
         if project_key.startswith("webservices-"):
             project_key = project_key.replace("webservices-", "ws-")
             project_status.pmc = "ws"
+        # Fixup data from accumulo-fluo_recipes
+        if "_" in project_key:
+            project_key = project_key.replace("_", "-")
 
         # TODO: Annotator is in both projects and ldap_projects
         # The projects version is called "incubator-annotator", with "incubator" as its pmc

--- a/atr/models/api.py
+++ b/atr/models/api.py
@@ -17,8 +17,9 @@
 
 import dataclasses
 import datetime
+import re
 from collections.abc import Callable, Sequence
-from typing import Annotated, Any, Literal, TypeVar
+from typing import Annotated, Any, Literal, Self, TypeVar
 
 import pydantic
 
@@ -316,8 +317,11 @@ class PolicyGetResults(schema.Strict):
     policy_vote_comment_template: str
 
 
-class PolicyUpdateArgs(schema.Strict):
-    project: safe.ProjectKey = schema.example("example")
+class PolicyArgsBase(schema.Strict):
+    """
+    Base class to allow one endpoint to take a project key and another not
+    """
+
     announce_release_subject: str | None = None
     announce_release_template: str | None = None
     binary_artifact_paths: list[str] | None = None
@@ -352,7 +356,7 @@ class PolicyUpdateArgs(schema.Strict):
         return v
 
     @pydantic.model_validator(mode="after")
-    def validate_policy_fields(self) -> "PolicyUpdateArgs":
+    def validate_policy_fields(self) -> Self:
         if ("manual_vote" in self.model_fields_set) and ("vote_mode" in self.model_fields_set):
             raise ValueError("Specify either 'manual_vote' or 'vote_mode', not both")
 
@@ -377,9 +381,75 @@ class PolicyUpdateArgs(schema.Strict):
         return self
 
 
+class PolicyUpdateArgs(PolicyArgsBase):
+    project: safe.ProjectKey = schema.example("example")
+
+
 class PolicyUpdateResults(schema.Strict):
     endpoint: Literal["/policy/update"] = schema.alias("endpoint")
     success: Literal[True] = schema.example(True)
+
+
+class ProjectConfigProjectArgs(schema.Strict):
+    name: str | None = None
+    description: str | None = None
+    short_description: str | None = None
+    homepage: pydantic.HttpUrl | None = None
+    lifecycle_page: pydantic.HttpUrl | None = None
+    download_page: pydantic.HttpUrl | None = None
+    bug_database: pydantic.HttpUrl | None = None
+    mailing_lists: pydantic.HttpUrl | None = None
+    repository: list[pydantic.AnyUrl] | None = None
+    standards: list[str] | None = None
+    # Changing any of these four reassigns existing releases to the cycle
+    # their version string now maps to.
+    version_method: sql.VersionMethod | None = None
+    version_pattern: str | None = None
+    cycle_match: str | None = None
+    branch_template: str | None = None
+
+    @pydantic.field_validator("version_method", mode="before")
+    @classmethod
+    def version_method_to_enum(cls, v):
+        if isinstance(v, str):
+            try:
+                return sql.VersionMethod(v)
+            except ValueError:
+                raise ValueError(f"'{v}' is not a valid VersionMethod")
+        return v
+
+    @pydantic.model_validator(mode="after")
+    def _validate_version_scheme(self) -> Self:
+        if ("version_method" in self.model_fields_set) and (self.version_method is None):
+            raise ValueError("Field 'version_method' does not accept null")
+        for field in ("version_pattern", "cycle_match"):
+            value = getattr(self, field)
+            if not (isinstance(value, str) and value.strip()):
+                continue
+            try:
+                compiled = re.compile(value.strip())
+            except re.error as exc:
+                raise ValueError(f"Invalid {field} regex: {exc}") from exc
+            if (field == "cycle_match") and (compiled.groups < 1):
+                raise ValueError("cycle_match must contain at least one capture group")
+        return self
+
+
+class ProjectConfigPolicyArgs(PolicyArgsBase):
+    pass
+
+
+class ProjectConfigArgs(schema.Strict):
+    project_key: safe.ProjectKey = schema.example("example")
+    committee_key: safe.CommitteeKey = schema.example("example")
+    project: ProjectConfigProjectArgs | None = None
+    policy: ProjectConfigPolicyArgs | None = None
+
+
+class ProjectConfigResults(schema.Strict):
+    endpoint: Literal["/project/config"] = schema.alias("endpoint")
+    success: Literal[True] = schema.example(True)
+    created: bool = schema.example(False)
 
 
 class ProjectReleasesResults(schema.Strict):

--- a/atr/models/safe.py
+++ b/atr/models/safe.py
@@ -25,6 +25,7 @@ from typing import Annotated, Any, Final
 import pydantic
 
 _ALPHANUM: Final = frozenset(string.ascii_letters + string.digits + "-")
+_PROJECT_CHARS: Final = _ALPHANUM | frozenset("+")
 _ASF_UID_CHARS: Final = frozenset(string.ascii_lowercase + string.digits + "-_")
 _NUMERIC: Final = frozenset(string.digits)
 _PATH_CHARS: Final = frozenset(string.ascii_letters + string.digits + "-._+~/()")
@@ -207,8 +208,12 @@ class Numeric(SafeType):
         return _NUMERIC
 
 
-class ProjectKey(Alphanumeric):
+class ProjectKey(SafeType):
     """A project name that has been validated for safety."""
+
+    @classmethod
+    def _valid_chars(cls) -> frozenset[str]:
+        return _PROJECT_CHARS
 
 
 class ReleaseKey(Alphanumeric):

--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -659,6 +659,7 @@ class WorkflowSSHKey(sqlmodel.SQLModel, table=True):
 class Committee(sqlmodel.SQLModel, table=True):
     key: str = sqlmodel.Field(unique=True, primary_key=True, **example("example"))
     name: str | None = sqlmodel.Field(default=None, **example("Example"))
+    charter: str | None = sqlmodel.Field(default=None, **example("Example"))
     # True only if this is an incubator podling with a PPMC
     is_podling: bool = sqlmodel.Field(default=False)
 

--- a/atr/storage/writers/policy.py
+++ b/atr/storage/writers/policy.py
@@ -222,6 +222,14 @@ class CommitteeMember(CommitteeParticipant):
         project_key: models.safe.ProjectKey,
         update: models.api.PolicyUpdateArgs,
     ) -> None:
+        await self._edit_policy_no_commit(project_key, update)
+        await self.__commit_and_log(str(project_key))
+
+    async def _edit_policy_no_commit(
+        self,
+        project_key: models.safe.ProjectKey,
+        update: models.api.PolicyUpdateArgs,
+    ) -> None:
         # TODO: Ideally we would centralise the validation in this method
         project, release_policy = await self.__get_or_create_policy(project_key)
         fields_to_update = update.model_fields_set - {"manual_vote", "project", "vote_mode"}
@@ -246,8 +254,6 @@ class CommitteeMember(CommitteeParticipant):
 
         for field in fields_to_update:
             setattr(release_policy, field, normalised_values[field])
-
-        await self.__commit_and_log(str(project_key))
 
     async def edit_finish(self, form: shared.projects.FinishPolicyForm) -> None:
         project_key = form.project_key
@@ -304,7 +310,7 @@ class CommitteeMember(CommitteeParticipant):
         project.cycle_match = cycle_match
         project.branch_template = form.branch_template.strip() or None
 
-        await self.__reassign_release_cycles(project)
+        await cycles.reassign_release_cycles(self.__data, project)
         await self.__commit_and_log(str(project_key))
 
     async def edit_vote(self, form: shared.projects.VotePolicyForm) -> None:
@@ -327,33 +333,6 @@ class CommitteeMember(CommitteeParticipant):
             raise ValueError(f"Unsupported vote mode: {release_policy.vote_mode}")
 
         await self.__commit_and_log(str(str(project_key)))
-
-    async def __reassign_release_cycles(self, project: models.sql.Project) -> None:
-        """Re-resolve cycle membership for every release in the project.
-
-        Releases whose version doesn't match the current `cycle_match` move
-        to the default cycle. New cycles get auto-created in the same
-        transaction.
-        """
-        releases = await self.__data.release(project_key=str(project.key)).all()
-        for release in releases:
-            try:
-                cycle_name = cycles.cycle_name_for_version(project, release.version)
-            except ValueError:
-                cycle_name = "default"
-            new_cycle_key = f"{project.key}-{cycle_name}"
-            if release.cycle_key == new_cycle_key:
-                continue
-            if not await self.__data.project_cycle(cycle_key=new_cycle_key).get():
-                self.__data.add(
-                    models.sql.ProjectCycle(
-                        cycle_key=new_cycle_key,
-                        cycle=cycle_name,
-                        project_key=project.key,
-                        lts=False,
-                    )
-                )
-            release.cycle_key = new_cycle_key
 
     async def __commit_and_log(self, project_key: str) -> None:
         await self.__data.commit()

--- a/atr/storage/writers/project.py
+++ b/atr/storage/writers/project.py
@@ -24,7 +24,9 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy.exc
 
+import atr.cycles as cycles
 import atr.db as db
+import atr.models.api as api
 import atr.models.safe as safe
 import atr.models.sql as sql
 import atr.registry as registry
@@ -143,6 +145,29 @@ class CommitteeMember(CommitteeParticipant):
         return False
 
     async def create(self, committee_key: safe.CommitteeKey, display_name: str, label: str) -> None:
+        try:
+            await self._build_and_add_project_no_commit(committee_key, display_name, label)
+            await self.__data.commit()
+        except sqlalchemy.exc.IntegrityError as e:
+            if (
+                isinstance(e.orig, sqlite3.IntegrityError)
+                and (e.orig.sqlite_errorcode == sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY)
+                and ("project.key" in str(e.orig))
+            ):
+                raise storage.AccessError(f"Project {label} already exists", status=409)
+            raise
+        self.__write_as.append_to_audit_log(
+            asf_uid=self.__asf_uid,
+            committee_key=str(committee_key),
+            project_key=label,
+        )
+
+    async def _build_and_add_project_no_commit(
+        self,
+        committee_key: safe.CommitteeKey,
+        display_name: str,
+        label: str,
+    ) -> sql.Project:
         super_project = None
         # TODO: Do we need to do any additional validation on the string value?
         # Get the base project to derive from
@@ -172,27 +197,10 @@ class CommitteeMember(CommitteeParticipant):
             created=datetime.datetime.now(datetime.UTC),
             created_by=self.__asf_uid,
         )
-
         if super_project and super_project.release_policy:
             project.release_policy = super_project.release_policy.duplicate()
-
-        try:
-            self.__data.add(project)
-            await self.__data.commit()
-            self.__write_as.append_to_audit_log(
-                asf_uid=self.__asf_uid,
-                committee_key=str(committee_key),
-                project_key=label,
-            )
-        except sqlalchemy.exc.IntegrityError as e:
-            if (
-                isinstance(e.orig, sqlite3.IntegrityError)
-                and (e.orig.sqlite_errorcode == sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY)
-                and ("project.key" in str(e.orig))
-            ):
-                raise storage.AccessError(f"Project {label} already exists", status=409)
-            else:
-                raise
+        self.__data.add(project)
+        return project
 
     async def delete(self, project_key: safe.ProjectKey) -> None:
         project = await self.__data.project(
@@ -276,6 +284,99 @@ class CommitteeMember(CommitteeParticipant):
             )
             return True
         return False
+
+    async def upsert_config(
+        self,
+        args: api.ProjectConfigArgs,
+    ) -> bool:
+        try:
+            await self.__data.begin_immediate()
+            project, created = await self._resolve_or_create_project_no_commit(args)
+            project_args = args.project
+            if (project_args is not None) and project_args.model_fields_set:
+                await self._apply_project_args_no_commit(project, project_args)
+            policy_args = args.policy
+            if (policy_args is not None) and policy_args.model_fields_set:
+                policy_update = api.PolicyUpdateArgs(
+                    project=args.project_key,
+                    **policy_args.model_dump(exclude_unset=True),
+                )
+                await self.__write_as.policy._edit_policy_no_commit(args.project_key, policy_update)
+            await self.__data.commit()
+        except sqlalchemy.exc.IntegrityError as e:
+            await self.__data.rollback()
+            if (
+                isinstance(e.orig, sqlite3.IntegrityError)
+                and (e.orig.sqlite_errorcode == sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY)
+                and ("project.key" in str(e.orig))
+            ):
+                raise storage.AccessError(f"Project {args.project_key} already exists", status=409)
+            raise
+        except Exception:
+            await self.__data.rollback()
+            raise
+
+        self.__write_as.append_to_audit_log(
+            asf_uid=self.__asf_uid,
+            committee_key=str(args.committee_key),
+            project_key=str(args.project_key),
+            created=created,
+        )
+        return created
+
+    async def _resolve_or_create_project_no_commit(
+        self,
+        args: api.ProjectConfigArgs,
+    ) -> tuple[sql.Project, bool]:
+        existing = await self.__data.project(key=str(args.project_key)).get()
+        if (existing is not None) and (existing.committee_key != str(args.committee_key)):
+            raise storage.AccessError(
+                f"Project '{args.project_key}' does not belong to committee '{args.committee_key}'",
+                status=400,
+            )
+        if existing is not None:
+            return existing, False
+        if (args.project is None) or (args.project.name is None) or (not args.project.name.strip()):
+            raise ValueError(f"Project '{args.project_key}' does not exist; project.name is required to create it")
+        project = await self._build_and_add_project_no_commit(
+            args.committee_key, display_name=args.project.name, label=str(args.project_key)
+        )
+        return project, True
+
+    async def _apply_project_args_no_commit(
+        self,
+        project: sql.Project,
+        args: api.ProjectConfigProjectArgs,
+    ) -> None:
+        str_fields = {
+            "name",
+            "description",
+            "short_description",
+            "homepage",
+            "lifecycle_page",
+            "download_page",
+            "bug_database",
+            "mailing_lists",
+            "version_pattern",
+            "cycle_match",
+            "branch_template",
+        }
+        list_fields = {"repository", "standards"}
+        version_scheme_fields = {"version_method", "version_pattern", "cycle_match", "branch_template"}
+        provided = args.model_fields_set
+
+        for field in str_fields & provided:
+            value = getattr(args, field)
+            if value is not None:
+                value = str(value).strip() or None
+            setattr(project, field, value)
+        for field in list_fields & provided:
+            setattr(project, field, [str(item) for item in getattr(args, field) or []])
+        if "version_method" in provided:
+            project.version_method = args.version_method or sql.VersionMethod.SIMPLE
+
+        if version_scheme_fields & provided:
+            await cycles.reassign_release_cycles(self.__data, project)
 
     def __current_categories(self, project: sql.Project) -> list[str]:
         return (

--- a/migrations/versions/0080_2026.05.13_8df23462.py
+++ b/migrations/versions/0080_2026.05.13_8df23462.py
@@ -1,0 +1,27 @@
+"""add charter to committee data
+
+Revision ID: 0080_2026.05.13_8df23462
+Revises: 0079_2026.05.12_c9f4a1d2
+Create Date: 2026-05-13 11:32:31.940938+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "0080_2026.05.13_8df23462"
+down_revision: str | None = "0079_2026.05.12_c9f4a1d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("committee", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("charter", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("committee", schema=None) as batch_op:
+        batch_op.drop_column("charter")

--- a/tests/unit/datasources/test_apache.py
+++ b/tests/unit/datasources/test_apache.py
@@ -20,17 +20,17 @@ import os
 from typing import Any
 
 from atr.datasources.apache import (
-    CommitteeData,
     GroupsData,
     LDAPProjectsData,
     PodlingsData,
     ProjectsData,
     RetiredCommitteeData,
+    WhimsyCommitteeData,
 )
 
 
 def test_committee_data_model():
-    committees = CommitteeData.model_validate(_load_test_data("committees"))
+    committees = WhimsyCommitteeData.model_validate(_load_test_data("committees"))
 
     assert committees is not None
     assert committees.pmc_count == 1


### PR DESCRIPTION
Schema built from policy fields and (now) complete metadata. The endpoint accepts partial models and updates in-place if the project exists already.

Added datasource changes too. PR closes #462, #465, #921