### PR TITLE
#911 - add artifact metadata to data model, add artifact signature count to signing keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .DS_Store
+.idea
 .env
 .hypothesis/
 .mypy_cache/

--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -22,6 +22,7 @@ from typing import Any, Final, Literal
 import aiofiles.os
 import asfquart.base as base
 import openpgp
+import pydantic
 import quart
 import quart_rate_limiter as rate_limiter
 import quart_schema
@@ -1883,6 +1884,69 @@ def _issuer_matches_component(
     fingerprint_matches = (not issuer_fingerprints) or (fingerprint in issuer_fingerprints)
     key_id_matches = (not issuer_key_ids) or (key_id in issuer_key_ids)
     return fingerprint_matches and key_id_matches
+
+
+class TestProjectStatusArgs(pydantic.BaseModel):
+    project_key: safe.ProjectKey
+
+
+@api.typed
+@api.auth.public
+async def test_activate_project(
+    _test_activate_project: Literal["test/activate-project"],
+    data: TestProjectStatusArgs,
+) -> DictResponse:
+    """
+    URL: POST /test/activate-project
+
+    Restore a project to ACTIVE status (test mode only).
+    """
+    if not config.is_test_mode():
+        return quart.abort(404)
+    async with db.session() as session:
+        project = await session.project(key=str(data.project_key)).get()
+        if not project:
+            return quart.abort(404)
+        project = await session.merge(project)
+        project.status = sql.ProjectStatus.ACTIVE
+        await session.commit()
+    return {"ok": True, "project_key": str(data.project_key)}, 200
+
+
+@api.typed
+@api.auth.public
+async def test_archive_project(
+    _test_archive_project: Literal["test/archive-project"],
+    data: TestProjectStatusArgs,
+) -> DictResponse:
+    """
+    URL: POST /test/archive-project
+
+    Set a project to RETIRED status (test mode only).
+    """
+    if not config.is_test_mode():
+        return quart.abort(404)
+    async with db.session() as session:
+        project = await session.project(key=str(data.project_key)).get()
+        if not project:
+            return quart.abort(404)
+        project = await session.merge(project)
+        project.status = sql.ProjectStatus.RETIRED
+        await session.commit()
+    return {"ok": True, "project_key": str(data.project_key)}, 200
+
+
+def _committee_keys_path(committee: sql.Committee) -> safe.StatePath:
+    downloads_dir = paths.get_downloads_dir()
+    if committee.is_podling:
+        return downloads_dir / "incubator" / committee.key / "KEYS"
+    return downloads_dir / committee.key / "KEYS"
+
+
+def _committee_keys_url(host: str, committee: sql.Committee) -> str:
+    if committee.is_podling:
+        return f"https://{host}/downloads/incubator/{committee.key}/KEYS"
+    return f"https://{host}/downloads/{committee.key}/KEYS"
 
 
 def _jwt_asf_uid() -> str:

--- a/atr/db/__init__.py
+++ b/atr/db/__init__.py
@@ -156,6 +156,45 @@ class Session(sqlalchemy.ext.asyncio.AsyncSession):
     async def begin_immediate(self) -> None:
         await self.execute(sqlalchemy.text("BEGIN IMMEDIATE"))
 
+    def artifact(
+        self,
+        project_key: Opt[str] = NOT_SET,
+        version: Opt[str] = NOT_SET,
+        artifact_path: Opt[str] = NOT_SET,
+        release_key: Opt[str | None] = NOT_SET,
+        key_fingerprint: Opt[str | None] = NOT_SET,
+        signature_path: Opt[str | None] = NOT_SET,
+        checksum_path: Opt[str | None] = NOT_SET,
+        classification: Opt[str | None] = NOT_SET,
+        svn_revision: Opt[int | None] = NOT_SET,
+        _release: bool = False,
+    ) -> Query[sql.Artifact]:
+        query = sqlmodel.select(sql.Artifact)
+
+        if is_defined(project_key):
+            query = query.where(sql.Artifact.project_key == project_key)
+        if is_defined(version):
+            query = query.where(sql.Artifact.version == version)
+        if is_defined(artifact_path):
+            query = query.where(sql.Artifact.artifact_path == artifact_path)
+        if is_defined(release_key):
+            query = query.where(sql.Artifact.release_key == release_key)
+        if is_defined(key_fingerprint):
+            query = query.where(sql.Artifact.key_fingerprint == key_fingerprint)
+        if is_defined(signature_path):
+            query = query.where(sql.Artifact.signature_path == signature_path)
+        if is_defined(checksum_path):
+            query = query.where(sql.Artifact.checksum_path == checksum_path)
+        if is_defined(classification):
+            query = query.where(sql.Artifact.classification == classification)
+        if is_defined(svn_revision):
+            query = query.where(sql.Artifact.svn_revision == svn_revision)
+
+        if _release:
+            query = query.options(joined_load(sql.Artifact.release))
+
+        return Query(self, query)
+
     def check_result(
         self,
         id: Opt[int] = NOT_SET,

--- a/atr/get/announce.py
+++ b/atr/get/announce.py
@@ -205,6 +205,9 @@ async def _render_page(
     page.append(_render_release_card(release))
     page.h2["Announce this release"]
 
+    if banner := render.archived_project_banner(release.project):
+        page.append(banner)
+
     announce_msg = ""
     policy = release.release_policy or release.project.release_policy
     if policy and policy.file_tag_mappings:

--- a/atr/get/committees.py
+++ b/atr/get/committees.py
@@ -19,6 +19,7 @@ import datetime
 from typing import Literal
 
 import asfquart.base as base
+import sqlalchemy
 import sqlmodel
 
 import atr.blueprints.get as get
@@ -67,6 +68,20 @@ async def view(session: web.Public, _committees: Literal["committees"], name: sa
         )
         names: dict[str, str | None] = {u.asfuid: u.name for u in user_rows.scalars().all()}
 
+        fingerprints = [k.fingerprint for k in committee.public_signing_keys]
+        artifact_counts: dict[str, int] = {}
+        if fingerprints:
+            via = sql.validate_instrumented_attribute
+            count_rows = await data.execute(
+                sqlalchemy.select(
+                    via(sql.Artifact.key_fingerprint),
+                    sqlalchemy.func.count(),
+                )
+                .where(via(sql.Artifact.key_fingerprint).in_(fingerprints))
+                .group_by(via(sql.Artifact.key_fingerprint))
+            )
+            artifact_counts = {fp: n for fp, n in count_rows.all() if fp is not None}
+
     project_list = list(committee.projects)
     signing_keys = sorted(
         committee.public_signing_keys,
@@ -85,6 +100,7 @@ async def view(session: web.Public, _committees: Literal["committees"], name: sa
         roster=roster,
         names=names,
         signing_keys=signing_keys,
+        artifact_counts=artifact_counts,
         algorithms=shared.algorithms,
         now=datetime.datetime.now(datetime.UTC),
         email_from_key=util.email_from_uid,

--- a/atr/get/compose.py
+++ b/atr/get/compose.py
@@ -200,11 +200,15 @@ async def selected(
         )[""],
     ]
 
+    archived_banner = render.archived_project_banner(release.project)
+    archived_banner_html = str(archived_banner) if archived_banner is not None else ""
+
     return await template.render(
         "check-selected.html",
         project_key=release.project.key,
         version_key=release.version,
         release=release,
+        archived_banner_html=archived_banner_html,
         release_vote_mode=release.effective_vote_mode,
         paths=all_paths,
         info=info,

--- a/atr/get/finish.py
+++ b/atr/get/finish.py
@@ -310,6 +310,9 @@ async def _render_page(
         htm.em[release.version],
     ]
 
+    if banner := render.archived_project_banner(release.project):
+        page.append(banner)
+
     # Release info card
     page.append(_render_release_card(release, announce_disable_message))
 

--- a/atr/get/keys.py
+++ b/atr/get/keys.py
@@ -21,6 +21,7 @@ from typing import Literal
 
 import htpy
 import quart
+import sqlalchemy
 
 import atr.blueprints.get as get
 import atr.db as db
@@ -209,6 +210,21 @@ async def keys(session: web.Committer, _keys: Literal["keys"]) -> str:
         user_keys = await data.public_signing_key(apache_uid=session.uid.lower(), _committees=True).all()
         user_ssh_keys = await data.ssh_key(asf_uid=session.uid).all()
         user_committees_with_keys = await data.committee(name_in=committees_to_query, _public_signing_keys=True).all()
+
+        all_fingerprints = [k.fingerprint for c in user_committees_with_keys for k in c.public_signing_keys]
+        artifact_counts: dict[str, int] = {}
+        if all_fingerprints:
+            via = sql.validate_instrumented_attribute
+            count_rows = await data.execute(
+                sqlalchemy.select(
+                    via(sql.Artifact.key_fingerprint),
+                    sqlalchemy.func.count(),
+                )
+                .where(via(sql.Artifact.key_fingerprint).in_(all_fingerprints))
+                .group_by(via(sql.Artifact.key_fingerprint))
+            )
+            artifact_counts = {fp: n for fp, n in count_rows.all() if fp is not None}
+
     for key in user_keys:
         key.committees.sort(key=lambda c: c.key)
 
@@ -228,7 +244,7 @@ async def keys(session: web.Committer, _keys: Literal["keys"]) -> str:
 
     await _openpgp_keys(page, list(user_keys))
     await _ssh_keys(page, list(user_ssh_keys))
-    await _committee_keys(page, list(user_committees_with_keys))
+    await _committee_keys(page, list(user_committees_with_keys), artifact_counts)
 
     return await template.blank(
         "Manage keys",
@@ -278,7 +294,11 @@ async def upload(_session: web.Committer, _keys_upload: Literal["keys/upload"]) 
     return await shared.keys.render_upload_page()
 
 
-async def _committee_keys(page: htm.Block, user_committees_with_keys: list[sql.Committee]) -> None:
+async def _committee_keys(
+    page: htm.Block,
+    user_committees_with_keys: list[sql.Committee],
+    artifact_counts: dict[str, int],
+) -> None:
     page.h2("#your-committee-keys")["Your committee's keys"]
     page.div(".mb-4")[htm.a(".btn.btn-outline-primary", href=util.as_url(upload))["Upload a KEYS file"]]
 
@@ -287,21 +307,36 @@ async def _committee_keys(page: htm.Block, user_committees_with_keys: list[sql.C
             page.h3(f"#committee-{committee.key}.mt-3")[committee.display_name or committee.key]
 
             if committee.public_signing_keys:
+                sorted_keys = sorted(
+                    committee.public_signing_keys,
+                    key=lambda k: (k.apache_uid or "", k.fingerprint[-16:]),
+                )
                 thead = htm.thead[
                     htm.tr[
                         htm.th(".px-2", scope="col")["Key ID"],
                         htm.th(".px-2", scope="col")["Email"],
                         htm.th(".px-2", scope="col")["Apache UID"],
+                        htm.th(".px-2", scope="col")["Role"],
+                        htm.th(".px-2.text-end", scope="col")["Artifacts"],
                     ]
                 ]
                 tbody = htm.Block(htm.tbody)
-                for key in committee.public_signing_keys:
+                for key in sorted_keys:
                     row = htm.Block(htm.tr)
                     details_url = util.as_url(details, fingerprint=key.fingerprint)
                     row.td(".text-break.font-monospace.px-2")[htm.a(href=details_url)[key.fingerprint[-16:].upper()]]
                     email = util.email_from_uid(key.primary_declared_uid) if key.primary_declared_uid else "-"
                     row.td(".text-break.px-2")[email or "-"]
                     row.td(".text-break.px-2")[key.apache_uid or "-"]
+                    uid = (key.apache_uid or "").lower()
+                    if uid in committee.committee_members:
+                        role = "PMC member"
+                    elif uid in committee.committers:
+                        role = "Committer"
+                    else:
+                        role = "-"
+                    row.td(".text-break.px-2")[role]
+                    row.td(".text-break.px-2.text-end")[str(artifact_counts.get(key.fingerprint, 0))]
                     tbody.append(row.collect())
 
                 page.div(".table-responsive.mb-2")[

--- a/atr/get/projects.py
+++ b/atr/get/projects.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Literal
 
 import asfquart.base as base
@@ -98,28 +99,55 @@ async def add_project(
 
 
 @get.typed
-async def projects(_session: web.Public, _projects: Literal["projects"]) -> str:
+async def projects(session: web.Public, _projects: Literal["projects"]) -> str:
     """
     URL: /projects
     Main project directory page.
     """
     async with db.session() as data:
-        projects = await data.project(_committee=True).order_by(sql.Project.name).all()
+        projects = await data.project(_committee=True, _releases=True).order_by(sql.Project.name).all()
 
-    delete_forms: dict[str, htm.Element] = {}
-    for project in projects:
-        delete_forms[str(project.key)] = await form.render(
-            model_cls=shared.projects.DeleteSelectedProject,
-            action=util.as_url(post.projects.delete),
-            form_classes=".d-inline-block.m-0",
-            submit_classes="btn-sm btn-outline-danger",
-            submit_label="Delete project",
-            empty=True,
-            defaults={"project_key": str(project.key)},
-            confirm="Are you sure you want to delete this project? This cannot be undone.",
-        )
+    committee_project_counts: Counter[str] = Counter(
+        str(p.committee.key) for p in projects if p.committee and p.status == sql.ProjectStatus.ACTIVE
+    )
 
-    return await template.render("projects.html", projects=projects, delete_forms=delete_forms)
+    action_forms: dict[str, htm.Element] = {}
+    if session is not None:
+        for project in projects:
+            if project.status != sql.ProjectStatus.ACTIVE:
+                continue
+            if not (user.is_committee_member(project.committee, session.uid) or session.is_admin):
+                continue
+            if project.committee and committee_project_counts[str(project.committee.key)] <= 1:
+                continue
+            if not project.releases:
+                action_forms[str(project.key)] = await form.render(
+                    model_cls=shared.projects.DeleteSelectedProject,
+                    action=util.as_url(post.projects.delete),
+                    form_classes=".d-inline-block.m-0",
+                    submit_classes="btn-sm btn-outline-danger",
+                    submit_label="Delete project",
+                    empty=True,
+                    defaults={"project_key": str(project.key)},
+                    confirm="Are you sure you want to delete this project? This cannot be undone.",
+                )
+            elif all(r.phase == sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT for r in project.releases):
+                action_forms[str(project.key)] = await form.render(
+                    model_cls=shared.projects.ArchiveSelectedProject,
+                    action=util.as_url(post.projects.archive),
+                    form_classes=".d-inline-block.m-0",
+                    submit_classes="btn-sm btn-outline-secondary",
+                    submit_label="Archive project",
+                    empty=True,
+                    defaults={"project_key": str(project.key)},
+                    confirm=(
+                        f"This project has {util.plural(len(project.releases), 'draft release')}."
+                        " Archiving will delete those drafts and mark the project as retired."
+                        " Continue?"
+                    ),
+                )
+
+    return await template.render("projects.html", projects=projects, action_forms=action_forms)
 
 
 @get.typed

--- a/atr/get/vote.py
+++ b/atr/get/vote.py
@@ -653,6 +653,7 @@ async def _render_trusted_vote_authenticated(
         _render_vote_delivery(
             page,
             archive_url,
+            release,
             vote_recipient,
             trusted_vote=True,
             recast=latest_ballot is not None,
@@ -695,7 +696,7 @@ async def _render_vote_authenticated(
 
     potency = binding_word if is_binding else non_binding_word
     _render_binding_status(page, is_binding, binding_committee, vote_round)
-    _render_vote_delivery(page, archive_url, vote_recipient, trusted_vote=False)
+    _render_vote_delivery(page, archive_url, release, vote_recipient, trusted_vote=False)
     vote_widget = _vote_decision_widget(potency)
     await _append_cast_vote_form(page, release, vote_widget)
 
@@ -703,6 +704,7 @@ async def _render_vote_authenticated(
 def _render_vote_delivery(
     page: htm.Block,
     archive_url: str | None,
+    release: sql.Release,
     vote_recipient: str,
     *,
     trusted_vote: bool,
@@ -731,6 +733,8 @@ def _render_vote_delivery(
         ]
     else:
         page.p["Your vote will be sent to ", htpy.code[vote_recipient], "."]
+    if banner := render.archived_project_banner(release.project):
+        page.append(banner)
 
 
 def _render_vote_manual(page: htm.Block) -> None:

--- a/atr/get/voting.py
+++ b/atr/get/voting.py
@@ -203,6 +203,9 @@ async def _render_page(
         htm.em[release.version],
     ]
 
+    if banner := render.archived_project_banner(release.project):
+        page.append(banner)
+
     page.div(".px-3.py-4.mb-4.bg-light.border.rounded")[
         htm.p(".mb-0")[
             "Starting a vote for this draft release will cause an email to be sent to the appropriate mailing list, "

--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -1190,6 +1190,10 @@ class Release(sqlmodel.SQLModel, table=True):
         back_populates="release", sa_relationship_kwargs={"cascade": "all, delete-orphan"}
     )
 
+    # 1-M: Release -> [Artifact]
+    # M-1: Artifact -> Release
+    artifacts: list["Artifact"] = sqlmodel.Relationship(back_populates="release")
+
     # The combination of key and version must be unique
     __table_args__ = (sqlmodel.UniqueConstraint("project_key", "version", name="unique_project_version"),)
 
@@ -1639,6 +1643,38 @@ class ReleaseFileState(sqlmodel.SQLModel, table=True):
             name="valid_release_file_state",
         ),
     )
+
+
+# Artifact: Project, Release, Signing Key
+class Artifact(sqlmodel.SQLModel, table=True):
+    project_key: str = sqlmodel.Field(
+        primary_key=True, foreign_key="project.key", ondelete="CASCADE", **example("example")
+    )
+    version: str = sqlmodel.Field(primary_key=True, **example("0.0.1"))
+    artifact_path: str = sqlmodel.Field(primary_key=True, **example("apache-example-0.0.1.tar.gz"))
+    # Link to ATR release record when one exists - null for historical SVN artifacts
+    release_key: str | None = sqlmodel.Field(
+        default=None, foreign_key="release.key", ondelete="CASCADE", index=True, **example("example-0.0.1")
+    )
+    # Fingerprint of the GPG public key used to sign the artifact
+    key_fingerprint: str | None = sqlmodel.Field(
+        default=None,
+        foreign_key="publicsigningkey.fingerprint",
+        ondelete="SET NULL",
+        index=True,
+        **example("0123456789abcdef0123456789abcdef01234567"),
+    )
+    # Path to the .asc detached signature file
+    signature_path: str | None = sqlmodel.Field(default=None, **example("apache-example-0.0.1.tar.gz.asc"))
+    # Path to the strongest available checksum file (SHA-512 preferred over SHA-256 over MD5)
+    checksum_path: str | None = sqlmodel.Field(default=None, **example("apache-example-0.0.1.tar.gz.sha512"))
+    classification: str | None = sqlmodel.Field(default=None, **example("source"))
+    # Per-artifact SVN revision - not all artifacts in a release are added in the same commit
+    svn_revision: int | None = sqlmodel.Field(default=None, index=True, **example(12345))
+
+    # M-1: Artifact -> Release
+    # 1-M: Release -> [Artifact]
+    release: Release | None = sqlmodel.Relationship(back_populates="artifacts")
 
 
 # ReleasePolicy: Project

--- a/atr/post/projects.py
+++ b/atr/post/projects.py
@@ -22,11 +22,14 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 import quart
 
 import atr.blueprints.post as post
+import atr.db as db
 import atr.get as get
 import atr.models.safe as safe
+import atr.models.sql as sql
 import atr.models.unsafe as unsafe
 import atr.shared as shared
 import atr.storage as storage
+import atr.util as util
 import atr.web as web
 
 if TYPE_CHECKING:
@@ -61,6 +64,47 @@ async def add_project(
     return await session.redirect(
         get.projects.view, project_key=label, success=f"Project '{display_name}' added successfully."
     )
+
+
+@post.typed
+async def archive(
+    session: web.Committer,
+    _project_archive: Literal["project/archive"],
+    archive_selected_project_form: shared.projects.ArchiveSelectedProject,
+) -> web.WerkzeugResponse:
+    """
+    URL: /project/archive
+    Archive a project as a PMC member. Any draft releases are deleted first - they
+    would otherwise be stranded, because release.delete rejects once a project is retired.
+    """
+    project_key = archive_selected_project_form.project_key
+
+    # Pull the draft list up front so we can both delete them and report a count
+    async with db.session() as data:
+        project = await data.project(key=str(project_key), _releases=True).get()
+        draft_versions: list[safe.VersionKey] = (
+            [
+                safe.VersionKey(r.version)
+                for r in project.releases
+                if r.phase == sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
+            ]
+            if project is not None
+            else []
+        )
+
+    async with storage.write(session) as write:
+        wacm = await write.as_project_committee_member(project_key)
+        try:
+            for version in draft_versions:
+                await wacm.release.delete(project_key, version)
+            await wacm.project.archive(project_key)
+        except storage.AccessError as e:
+            return await session.redirect(get.projects.projects, error=f"Error archiving project: {e}")
+
+    success = f"Project '{project_key}' archived successfully."
+    if draft_versions:
+        success += f" Deleted {util.plural(len(draft_versions), 'draft release')}."
+    return await session.redirect(get.projects.projects, success=success)
 
 
 @post.typed

--- a/atr/render.py
+++ b/atr/render.py
@@ -92,6 +92,15 @@ _STATUS_LABELS: Final[dict[sql.CheckResultStatus, str]] = {
 }
 
 
+def archived_project_banner(project: sql.Project) -> htm.Element | None:
+    # Shown on the five top-level release pages when the PMC has archived the
+    # project. The storage layer still refuses the write, but the banner tells
+    # the viewer why the buttons are inert.
+    if project.status != sql.ProjectStatus.RETIRED:
+        return None
+    return htm.div(".alert.alert-warning.mb-4")["This project is archived. Release actions are disabled."]
+
+
 def highest_severity(
     counts: Mapping[sql.CheckResultStatus, int],
 ) -> sql.CheckResultStatus | None:

--- a/atr/shared/projects.py
+++ b/atr/shared/projects.py
@@ -355,6 +355,10 @@ class RemoveLanguageForm(form.Form):
     language_to_remove: str = form.label("Language to remove", widget=form.Widget.HIDDEN)
 
 
+class ArchiveSelectedProject(form.Form):
+    project_key: safe.ProjectKey = form.label("Project name", widget=form.Widget.HIDDEN)
+
+
 class DeleteProjectForm(form.Form):
     variant: DELETE_PROJECT = form.value(DELETE_PROJECT)
     project_key: safe.ProjectKey = form.label("Project name", widget=form.Widget.HIDDEN)

--- a/atr/storage/__init__.py
+++ b/atr/storage/__init__.py
@@ -528,3 +528,9 @@ async def write_as_project_committee_member(
 ) -> AsyncGenerator[WriteAsCommitteeMember]:
     async with write(asf_uid) as w:
         yield await w.as_project_committee_member(project_key)
+
+
+def ensure_project_active(project: sql.Project) -> None:
+    if project.status == sql.ProjectStatus.ACTIVE:
+        return
+    raise AccessError(f"Project '{project.key}' is archived; release actions are disabled.")

--- a/atr/storage/writers/announce.py
+++ b/atr/storage/writers/announce.py
@@ -137,6 +137,7 @@ class CommitteeMember(CommitteeParticipant):
                 status=404,
             )
         )
+        storage.ensure_project_active(release.project)
         if (committee := release.project.committee) is None:
             raise storage.AccessError("Release has no committee - Invalid state", status=500)
 

--- a/atr/storage/writers/checks.py
+++ b/atr/storage/writers/checks.py
@@ -185,6 +185,7 @@ class CommitteeMember(CommitteeParticipant):
             raise storage.AccessError(f"Project {project_key} not found", status=404)
         if project.committee_key != self.__committee_key:
             raise storage.AccessError(f"Project {project_key} is not in committee {self.__committee_key}", status=403)
+        storage.ensure_project_active(project)
 
 
 def _validate_ignore_patterns(*patterns: str | None) -> None:

--- a/atr/storage/writers/distributions.py
+++ b/atr/storage/writers/distributions.py
@@ -106,6 +106,10 @@ class CommitteeMember(CommitteeParticipant):
         version: models.safe.VersionKey,
         staging: bool,
     ) -> models.sql.Task:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         dist_task = models.sql.Task(
             task_type=models.sql.TaskType.DISTRIBUTION_WORKFLOW,
             task_args=args.DistributionWorkflow(
@@ -153,6 +157,10 @@ class CommitteeMember(CommitteeParticipant):
         api_url: str | None = None,
         web_url: str | None = None,
     ) -> tuple[models.sql.Distribution, bool]:
+        release = await self.__data.release(key=str(release_key), _project=True).demand(
+            storage.AccessError(f"Release '{release_key}' not found.")
+        )
+        storage.ensure_project_active(release.project)
         namespace = str(owner_namespace) if owner_namespace else ""
         existing = await self.__data.distribution(
             str(release_key), platform, namespace, str(package), str(version)
@@ -220,6 +228,10 @@ class CommitteeMember(CommitteeParticipant):
         dd: models.distribution.Data,
         allow_retries: bool = False,
     ) -> tuple[models.sql.Distribution, bool, models.distribution.Metadata | None]:
+        release = await self.__data.release(key=str(release_key), _project=True).demand(
+            storage.AccessError(f"Release '{release_key}' not found.")
+        )
+        storage.ensure_project_active(release.project)
         api_url = distribution.get_api_url(dd, staging)
         if dd.platform == models.sql.DistributionPlatform.MAVEN:
             api_oc = await distribution.json_from_maven_xml(api_url, dd.version)
@@ -308,6 +320,10 @@ class CommitteeMember(CommitteeParticipant):
         package: str,
         version: str,
     ) -> None:
+        release = await self.__data.release(key=str(release_key), _project=True).demand(
+            storage.AccessError(f"Release '{release_key}' not found.")
+        )
+        storage.ensure_project_active(release.project)
         distribution = await self.__data.distribution(
             release_key=str(release_key),
             platform=platform,

--- a/atr/storage/writers/project.py
+++ b/atr/storage/writers/project.py
@@ -102,6 +102,7 @@ class CommitteeMember(CommitteeParticipant):
         project = await self.__data.project(key=str(project_key)).get()
         if not project:
             raise storage.AccessError(f"Project '{project_key}' not found.", status=404)
+        storage.ensure_project_active(project)
         new_category = new_category.strip()
         current_categories = self.__current_categories(project)
         if new_category and (new_category not in current_categories):
@@ -129,6 +130,7 @@ class CommitteeMember(CommitteeParticipant):
         project = await self.__data.project(key=str(project_key)).get()
         if not project:
             raise storage.AccessError(f"Project '{project_key}' not found.", status=404)
+        storage.ensure_project_active(project)
         current_categories = self.__current_categories(project)
         if action_value in current_categories:
             if action_value in registry.FORBIDDEN_PROJECT_CATEGORIES:
@@ -209,18 +211,61 @@ class CommitteeMember(CommitteeParticipant):
         self.__data.add(project)
         return project
 
+    async def archive(self, project_key: safe.ProjectKey) -> None:
+        project = await self.__data.project(key=str(project_key), status=sql.ProjectStatus.ACTIVE, _releases=True).get()
+
+        if not project:
+            raise storage.AccessError(f"Project '{project_key}' not found.")
+
+        # TODO: when a project has current or archived releases, archiving the project
+        # should be allowed and should cascade-archive the current releases as well -
+        # for now we just block, and only drafts are handled (deleted by the caller)
+        post_draft_phases = {
+            sql.ReleasePhase.RELEASE_CANDIDATE,
+            sql.ReleasePhase.RELEASE_PREVIEW,
+            sql.ReleasePhase.RELEASE,
+        }
+        if any(r.phase in post_draft_phases for r in project.releases):
+            raise storage.AccessError(
+                f"Cannot archive project '{project_key}' because it has active releases; complete or remove them first."
+            )
+
+        if project.committee_key:
+            committee_projects = await self.__data.project(
+                committee_key=project.committee_key, status=sql.ProjectStatus.ACTIVE
+            ).all()
+            if len(committee_projects) <= 1:
+                raise storage.AccessError(
+                    f"Cannot archive project '{project_key}' because it is the only project in its committee."
+                )
+
+        project = await self.__data.merge(project)
+        project.status = sql.ProjectStatus.RETIRED
+        await self.__data.commit()
+        self.__write_as.append_to_audit_log(
+            asf_uid=self.__asf_uid,
+            project_key=str(project_key),
+        )
+
     async def delete(self, project_key: safe.ProjectKey) -> None:
-        project = await self.__data.project(
-            key=str(project_key), status=sql.ProjectStatus.ACTIVE, _releases=True, _distribution_channels=True
-        ).get()
+        project = await self.__data.project(key=str(project_key), status=sql.ProjectStatus.ACTIVE, _releases=True).get()
 
         if not project:
             raise storage.AccessError(f"Project '{project_key}' not found.", status=404)
 
-        # Prevent deletion if there are associated releases or channels
+        if project.committee_key:
+            committee_projects = await self.__data.project(
+                committee_key=project.committee_key, status=sql.ProjectStatus.ACTIVE
+            ).all()
+            if len(committee_projects) <= 1:
+                raise storage.AccessError(
+                    f"Cannot delete project '{project_key}' because it is the only project in its committee."
+                )
+
         if project.releases:
             raise storage.AccessError(
-                f"Cannot delete project '{project_key}' because it has associated releases.", status=409
+                f"Cannot delete project '{project_key}' because it has associated releases. Delete them first.",
+                status=409,
             )
 
         await self.__data.delete(project)
@@ -350,6 +395,7 @@ class CommitteeMember(CommitteeParticipant):
                 status=400,
             )
         if existing is not None:
+            storage.ensure_project_active(existing)
             return existing, False
         if (args.project is None) or (args.project.name is None) or (not args.project.name.strip()):
             raise ValueError(f"Project '{args.project_key}' does not exist; project.name is required to create it")

--- a/atr/storage/writers/release.py
+++ b/atr/storage/writers/release.py
@@ -177,6 +177,7 @@ class CommitteeParticipant(FoundationCommitter):
         release = await self.__data.release(
             project_key=str(project_key), version=str(version), phase=phase, _committee=True
         ).demand(storage.AccessError(f"Release '{project_key!s} {version!s}' not found.", status=404))
+        storage.ensure_project_active(release.project)
         release_dirs = [
             paths.release_directory_base(release),
             paths.get_attestable_dir() / str(project_key) / str(version),
@@ -393,6 +394,10 @@ class CommitteeParticipant(FoundationCommitter):
         svn_revision: str,
         target_subdirectory: safe.RelPath | None,
     ) -> sql.Task:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         task_args = {
             "svn_url": svn_url,
             "revision": svn_revision,
@@ -496,6 +501,7 @@ class CommitteeParticipant(FoundationCommitter):
         release_for_pre_checks = await self.__data.release(
             key=str(release_key), _project=True, _committee=True, _project_release_policy=True
         ).demand(storage.AccessError("Release candidate draft not found", status=404))
+        storage.ensure_project_active(release_for_pre_checks.project)
         project_key = release_for_pre_checks.safe_project_key
         version_key = release_for_pre_checks.safe_version_key
         revision_number = release_for_pre_checks.safe_latest_revision_number

--- a/atr/storage/writers/revision.py
+++ b/atr/storage/writers/revision.py
@@ -394,6 +394,10 @@ class CommitteeParticipant(FoundationCommitter):
         version_key: safe.VersionKey,
         quarantined_id: int,
     ) -> None:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         release_key = sql.release_key(str(project_key), str(version_key))
         quarantined = await self.__data.quarantined(
             id=quarantined_id, release_key=release_key, status=sql.QuarantineStatus.FAILED
@@ -432,6 +436,7 @@ class CommitteeParticipant(FoundationCommitter):
             release = await data.release(key=release_key, _release_policy=True, _project_release_policy=True).demand(
                 RuntimeError("Release does not exist for new revision creation")
             )
+            storage.ensure_project_active(release.project)
             if release.phase not in allowed_phases:
                 raise types.PhaseMismatchError(
                     f"Cannot create revision: release phase is {release.phase.value}, "
@@ -609,7 +614,9 @@ class CommitteeParticipant(FoundationCommitter):
         if len(tag.encode("utf-8")) > 256:
             raise storage.AccessError("Tag must be at most 256 bytes", status=400)
 
-        release_key = sql.release_key(str(project_key), str(version_key))
+        release_key = str(sql.release_key(project_key, version_key))
+        release = await self.__data.release(release_key).demand(storage.AccessError("No release found"))
+        storage.ensure_project_active(release.project)
         via = sql.validate_instrumented_attribute
         stmt = (
             sqlmodel.update(sql.Revision)

--- a/atr/storage/writers/sbom.py
+++ b/atr/storage/writers/sbom.py
@@ -79,6 +79,10 @@ class CommitteeParticipant(FoundationCommitter):
         revision_number: safe.RevisionNumber,
         rel_path: safe.RelPath,
     ) -> sql.Task:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         sbom_task = sql.Task(
             task_type=sql.TaskType.SBOM_AUGMENT,
             task_args=args.FileArgs(
@@ -109,6 +113,10 @@ class CommitteeParticipant(FoundationCommitter):
         file_path: safe.StatePath,
         sbom_path: safe.StatePath,
     ) -> sql.Task:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         sbom_task = sql.Task(
             task_type=sql.TaskType.SBOM_CONVERT,
             task_args=args.ConvertCycloneDX(
@@ -136,6 +144,10 @@ class CommitteeParticipant(FoundationCommitter):
         path_in_new_revision: safe.StatePath,
         sbom_path_in_new_revision: safe.StatePath,
     ) -> sql.Task:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         # Create and queue the task, using paths within the new revision
         # We still need release.name for the task metadata
         artifact_path = await asyncio.to_thread(_resolved_path_str, path_in_new_revision)
@@ -165,6 +177,10 @@ class CommitteeParticipant(FoundationCommitter):
         revision_number: safe.RevisionNumber,
         rel_path: safe.RelPath,
     ) -> sql.Task:
+        project = await self.__data.project(key=str(project_key)).demand(
+            storage.AccessError(f"Project '{project_key}' not found.")
+        )
+        storage.ensure_project_active(project)
         sbom_task = sql.Task(
             task_type=sql.TaskType.SBOM_OSV_SCAN,
             task_args=args.FileArgs(

--- a/atr/storage/writers/vote.py
+++ b/atr/storage/writers/vote.py
@@ -234,6 +234,7 @@ class CommitteeParticipant(FoundationCommitter):
         fullname: str,
         is_binding: bool = False,
     ) -> tuple[list[str], str]:
+        storage.ensure_project_active(release.project)
         # Get the email thread
         latest_vote_task = await interaction.release_current_vote_task(release)
         if latest_vote_task is None:
@@ -310,6 +311,14 @@ class CommitteeParticipant(FoundationCommitter):
         automatic_resolve_when_finished: bool = False,
         acknowledged_concerns: frozenset[str] = frozenset(),
     ) -> sql.Task:
+        if release is None:
+            release = await self.__data.release(
+                project_key=str(project_key),
+                version=str(version_key),
+                _project=True,
+                _committee=True,
+            ).demand(storage.AccessError("Release not found", status=404))
+        storage.ensure_project_active(release.project)
         if promote:
             await self.__data.begin_immediate()
         try:
@@ -329,13 +338,6 @@ class CommitteeParticipant(FoundationCommitter):
                     acknowledged_concerns=acknowledged_concerns,
                 )
             else:
-                if release is None:
-                    release = await self.__data.release(
-                        project_key=str(project_key),
-                        version=str(version_key),
-                        _project=True,
-                        _committee=True,
-                    ).demand(storage.AccessError("Release not found", status=404))
                 release, vote_seq, vote_mode, revision_number = await self.__write_as.release._start_vote_no_commit(
                     release.safe_key,
                     expected_revision,
@@ -480,6 +482,7 @@ class CommitteeMember(CommitteeParticipant):
             _release_policy=True,
             _project_release_policy=True,
         ).demand(storage.AccessError("Release not found", status=404))
+        storage.ensure_project_active(release.project)
         if (expected_vote_mode is not None) and (release.effective_vote_mode != expected_vote_mode):
             raise storage.AccessError("The resolve form is stale, please refresh and try again", status=409)
         if release.effective_vote_mode == sql.VoteMode.MANUAL:
@@ -570,6 +573,7 @@ class CommitteeMember(CommitteeParticipant):
             _release_policy=True,
             _project_release_policy=True,
         ).demand(storage.AccessError("Release not found", status=404))
+        storage.ensure_project_active(release.project)
 
         if release.effective_vote_mode != sql.VoteMode.MANUAL:
             raise storage.AccessError("Release is not configured for manual voting", status=409)
@@ -643,6 +647,7 @@ class CommitteeMember(CommitteeParticipant):
             await self.__data.begin_immediate()
         # Attach the existing release to the session
         release = await self.__data.merge(release)
+        storage.ensure_project_active(release.project)
         # Update the release phase based on vote result
         extra_destination = None
         second_round_vote_seq = None
@@ -803,6 +808,7 @@ class CommitteeMember(CommitteeParticipant):
         latest_vote_task: sql.Task,
         extra_destination: tuple[str, str] | None = None,
     ) -> str | None:
+        storage.ensure_project_active(release.project)
         # Get the email thread
         vote_thread_mid = interaction.task_mid_get(latest_vote_task)
         if vote_thread_mid is None:

--- a/atr/templates/check-selected.html
+++ b/atr/templates/check-selected.html
@@ -79,6 +79,10 @@
     </p>
   {% endif %}
 
+  {% if archived_banner_html %}
+    {{ archived_banner_html|safe }}
+  {% endif %}
+
   <div id="release-info-container">
     {{ release_info_html|safe }}
   </div>

--- a/atr/templates/committee-view.html
+++ b/atr/templates/committee-view.html
@@ -139,6 +139,7 @@
                   <th class="px-2" scope="col">Email</th>
                   <th class="px-2" scope="col">Apache UID</th>
                   <th class="px-2" scope="col">Role</th>
+                  <th class="px-2 text-end" scope="col">Artifacts</th>
                 </tr>
               </thead>
               <tbody>
@@ -158,6 +159,7 @@
                         <span class="text-muted">−</span>
                       {% endif %}
                     </td>
+                    <td class="px-2 text-end">{{ artifact_counts.get(key.fingerprint, 0) }}</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/atr/templates/projects.html
+++ b/atr/templates/projects.html
@@ -71,9 +71,7 @@
             </div>
           {% endif %}
 
-            {# TODO: Could add "or is_viewing_as_admin_fn(current_user.uid)" #}
-            {# But then the page is noisy for admins #}
-          {% if project.created_by == current_user.uid %}<div class="mt-3 position-relative z-1">{{ delete_forms[project.key] }}</div>{% endif %}
+          {% if project.key in action_forms %}<div class="mt-3 position-relative z-1">{{ action_forms[project.key] }}</div>{% endif %}
 
         </div>
       </div>

--- a/migrations/versions/0083_2026.05.14_7c4f8a2e.py
+++ b/migrations/versions/0083_2026.05.14_7c4f8a2e.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add Artifact catalog model for issue 911
+
+Revision ID: 0083_2026.05.14_7c4f8a2e
+Revises: 0082_2026.05.14_a1b2c3d4
+Create Date: 2026-05-14 16:01:57.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "0083_2026.05.14_7c4f8a2e"
+down_revision: str | None = "0082_2026.05.14_a1b2c3d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "artifact",
+        sa.Column("project_key", sa.String(), nullable=False),
+        sa.Column("version", sa.String(), nullable=False),
+        sa.Column("artifact_path", sa.String(), nullable=False),
+        sa.Column("release_key", sa.String(), nullable=True),
+        sa.Column("key_fingerprint", sa.String(), nullable=True),
+        sa.Column("signature_path", sa.String(), nullable=True),
+        sa.Column("checksum_path", sa.String(), nullable=True),
+        sa.Column("classification", sa.String(), nullable=True),
+        sa.Column("svn_revision", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["project_key"],
+            ["project.key"],
+            name=op.f("fk_artifact_project_key_project"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["release_key"],
+            ["release.key"],
+            name=op.f("fk_artifact_release_key_release"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["key_fingerprint"],
+            ["publicsigningkey.fingerprint"],
+            name=op.f("fk_artifact_key_fingerprint_publicsigningkey"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("project_key", "version", "artifact_path", name=op.f("pk_artifact")),
+    )
+    with op.batch_alter_table("artifact", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_artifact_release_key"), ["release_key"], unique=False)
+        batch_op.create_index(batch_op.f("ix_artifact_key_fingerprint"), ["key_fingerprint"], unique=False)
+        batch_op.create_index(batch_op.f("ix_artifact_svn_revision"), ["svn_revision"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_table("artifact")

--- a/playwright/test.py
+++ b/playwright/test.py
@@ -595,7 +595,6 @@ def test_all(page: Page, credentials: Credentials, skip_slow: bool) -> None:
         test_session_01_banned_user_is_rejected,
         test_session_02_recheck_allows_active_user,
     ]
-
     # Order between our tests must be preserved
     # Insertion order is reliable since Python 3.6
     # Therefore iteration over tests matches the insertion order above

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -29,6 +29,13 @@ def api_get(request: APIRequestContext, path: str) -> dict[str, Any]:
     return response.json()
 
 
+def api_post(request: APIRequestContext, path: str, data: dict[str, Any]) -> dict[str, Any]:
+    response = request.post(f"{_ATR_BASE_URL}{path}", data=data)
+    if not response.ok:
+        raise RuntimeError(f"POST {path} failed with status {response.status}: {response.text()}")
+    return response.json()
+
+
 def delete_release_if_exists(page: Page, project_key: str, version_key: str) -> None:
     release_key = f"{project_key}-{version_key}"
     visit(page, "/admin/delete-release")

--- a/tests/e2e/projects/__init__.py
+++ b/tests/e2e/projects/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/e2e/projects/conftest.py
+++ b/tests/e2e/projects/conftest.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import e2e.helpers as helpers
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from playwright.sync_api import Browser, BrowserContext, Page
+
+PROJECT_KEY: Final[str] = "test"
+VERSION_KEY: Final[str] = "0.1+e2e-projects"
+COMPOSE_URL: Final[str] = f"/compose/{PROJECT_KEY}/{VERSION_KEY}"
+
+
+@pytest.fixture(scope="module")
+def projects_context(browser: Browser) -> Generator[BrowserContext]:
+    context = browser.new_context(ignore_https_errors=True)
+    page = context.new_page()
+    helpers.log_in(page)
+    helpers.delete_release_if_exists(page, PROJECT_KEY, VERSION_KEY)
+    helpers.visit(page, f"/start/{PROJECT_KEY}")
+    page.locator("input#version_key").fill(VERSION_KEY)
+    page.get_by_role("button", name="Start new release").click()
+    page.wait_for_url(f"**/compose/{PROJECT_KEY}/{VERSION_KEY}")
+    page.close()
+    yield context
+    cleanup = context.new_page()
+    helpers.api_post(cleanup.request, "/api/test/activate-project", {"project_key": PROJECT_KEY})
+    helpers.delete_release_if_exists(cleanup, PROJECT_KEY, VERSION_KEY)
+    cleanup.close()
+    context.close()
+
+
+@pytest.fixture
+def page_active(projects_context: BrowserContext) -> Generator[Page]:
+    page = projects_context.new_page()
+    helpers.visit(page, COMPOSE_URL)
+    yield page
+    page.close()
+
+
+@pytest.fixture
+def page_archived(projects_context: BrowserContext) -> Generator[Page]:
+    page = projects_context.new_page()
+    helpers.api_post(page.request, "/api/test/archive-project", {"project_key": PROJECT_KEY})
+    helpers.visit(page, COMPOSE_URL)
+    yield page
+    helpers.api_post(page.request, "/api/test/activate-project", {"project_key": PROJECT_KEY})
+    page.close()

--- a/tests/e2e/projects/test_get.py
+++ b/tests/e2e/projects/test_get.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from playwright.sync_api import Page, expect
+
+
+def test_archive_banner_absent_when_active(page_active: Page) -> None:
+    """No archive warning banner on the compose page when the project is active."""
+    expect(page_active.locator(".alert-warning:has-text('archived')")).not_to_be_visible()
+
+
+def test_archive_banner_visible_when_archived(page_archived: Page) -> None:
+    """Archive warning banner appears on the compose page when the project is archived."""
+    expect(page_archived.locator(".alert-warning:has-text('archived')")).to_be_visible()

--- a/tests/unit/test_archived_project_guard.py
+++ b/tests/unit/test_archived_project_guard.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from types import SimpleNamespace
+
+import htpy
+import pytest
+
+import atr.models.sql as sql
+import atr.render as render
+import atr.storage as storage
+
+
+def test_ensure_project_active_returns_none_for_active() -> None:
+    project = SimpleNamespace(key="p", status=sql.ProjectStatus.ACTIVE)
+    assert storage.ensure_project_active(project) is None
+
+
+def test_ensure_project_active_raises_for_retired() -> None:
+    project = SimpleNamespace(key="p", status=sql.ProjectStatus.RETIRED)
+    with pytest.raises(storage.AccessError, match="archived") as excinfo:
+        storage.ensure_project_active(project)
+    assert "'p'" in str(excinfo.value)
+
+
+def test_archived_project_banner_returns_none_for_active() -> None:
+    project = SimpleNamespace(status=sql.ProjectStatus.ACTIVE)
+    assert render.archived_project_banner(project) is None
+
+
+def test_archived_project_banner_returns_element_for_retired() -> None:
+    project = SimpleNamespace(status=sql.ProjectStatus.RETIRED)
+    banner = render.archived_project_banner(project)
+    assert isinstance(banner, htpy.Element)
+    html = str(banner)
+    assert "alert-warning" in html
+    assert "archived" in html

--- a/tests/unit/test_archived_project_writer_guards.py
+++ b/tests/unit/test_archived_project_writer_guards.py
@@ -1,0 +1,305 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest.mock as mock
+from types import SimpleNamespace
+
+import pytest
+
+import atr.models.safe as safe
+import atr.models.sql as sql
+import atr.storage as storage
+import atr.storage.writers.announce as announce
+import atr.storage.writers.checks as checks
+import atr.storage.writers.distributions as distributions
+import atr.storage.writers.release as release
+import atr.storage.writers.revision as revision
+import atr.storage.writers.sbom as sbom
+import atr.storage.writers.vote as vote
+
+
+def _retired_project(key: str = "project") -> SimpleNamespace:
+    return SimpleNamespace(
+        key=key,
+        status=sql.ProjectStatus.RETIRED,
+        committee_key=key,
+        display_name=key.capitalize(),
+        short_display_name=key.capitalize(),
+    )
+
+
+def _retired_release(project_key: str = "project", version: str = "1.0.0") -> SimpleNamespace:
+    return SimpleNamespace(
+        key=sql.release_key(project_key, version),
+        project=_retired_project(project_key),
+        version=version,
+    )
+
+
+def _query_returning(obj: object) -> mock.MagicMock:
+    query = mock.MagicMock()
+    query.demand = mock.AsyncMock(return_value=obj)
+    query.get = mock.AsyncMock(return_value=obj)
+    return query
+
+
+def _async_context_manager(value: object) -> mock.MagicMock:
+    ctx = mock.MagicMock()
+    ctx.__aenter__ = mock.AsyncMock(return_value=value)
+    ctx.__aexit__ = mock.AsyncMock(return_value=None)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_announce_release_blocks_retired(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        announce.util,
+        "permitted_announce_recipients",
+        lambda _uid: {"dev@project.apache.org"},
+    )
+    data = mock.MagicMock()
+    data.release = mock.MagicMock(return_value=_query_returning(_retired_release()))
+    writer = object.__new__(announce.CommitteeMember)
+    writer._CommitteeMember__data = data
+    writer._CommitteeMember__asf_uid = "tester"
+    writer._CommitteeMember__committee_key = "project"
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.release(
+            safe.ProjectKey("project"),
+            safe.VersionKey("1.0.0"),
+            safe.RevisionNumber("00001"),
+            "dev@project.apache.org",
+            "body",
+            None,
+            "tester",
+            "Chair",
+        )
+
+
+@pytest.mark.asyncio
+async def test_checks_ignore_add_propagates_chokepoint_block() -> None:
+    data = mock.MagicMock()
+    data.project = mock.MagicMock(return_value=_query_returning(_retired_project()))
+    writer = object.__new__(checks.CommitteeMember)
+    writer._CommitteeMember__data = data
+    writer._CommitteeMember__asf_uid = "tester"
+    writer._CommitteeMember__committee_key = "project"
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.ignore_add(safe.ProjectKey("project"))
+
+
+@pytest.mark.asyncio
+async def test_distributions_automate_blocks_retired() -> None:
+    data = mock.MagicMock()
+    data.project = mock.MagicMock(return_value=_query_returning(_retired_project()))
+    writer = object.__new__(distributions.CommitteeMember)
+    writer._CommitteeMember__data = data
+    writer._CommitteeMember__asf_uid = "tester"
+    writer._CommitteeMember__committee_key = "project"
+
+    platform = next(iter(sql.DistributionPlatform))
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.automate(
+            safe.ReleaseKey("project-1.0.0"),
+            platform,
+            "project",
+            None,
+            safe.ProjectKey("project"),
+            safe.VersionKey("1.0.0"),
+            "release",
+            None,
+            safe.Alphanumeric("pkg"),
+            safe.VersionKey("1.0.0"),
+            False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_distributions_record_blocks_retired_via_release_lookup() -> None:
+    data = mock.MagicMock()
+    data.release = mock.MagicMock(return_value=_query_returning(_retired_release()))
+    writer = object.__new__(distributions.CommitteeMember)
+    writer._CommitteeMember__data = data
+    writer._CommitteeMember__asf_uid = "tester"
+    writer._CommitteeMember__committee_key = "project"
+
+    platform = next(iter(sql.DistributionPlatform))
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.record(
+            safe.ReleaseKey("project-1.0.0"),
+            platform,
+            None,
+            safe.Alphanumeric("pkg"),
+            safe.VersionKey("1.0.0"),
+            False,
+            False,
+            None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_release_delete_blocks_retired() -> None:
+    data = mock.MagicMock()
+    data.release = mock.MagicMock(return_value=_query_returning(_retired_release()))
+    writer = object.__new__(release.CommitteeParticipant)
+    writer._CommitteeParticipant__data = data
+    writer._CommitteeParticipant__asf_uid = "tester"
+    writer._CommitteeParticipant__committee_key = "project"
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.delete(safe.ProjectKey("project"), safe.VersionKey("1.0.0"))
+
+
+@pytest.mark.asyncio
+async def test_release_import_from_svn_blocks_retired() -> None:
+    data = mock.MagicMock()
+    data.project = mock.MagicMock(return_value=_query_returning(_retired_project()))
+    writer = object.__new__(release.CommitteeParticipant)
+    writer._CommitteeParticipant__data = data
+    writer._CommitteeParticipant__asf_uid = "tester"
+    writer._CommitteeParticipant__committee_key = "project"
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.import_from_svn(
+            safe.ProjectKey("project"),
+            safe.VersionKey("1.0.0"),
+            safe.RelPath("svn/url"),
+            "r1",
+            None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_release_promote_to_candidate_blocks_retired() -> None:
+    data = mock.MagicMock()
+    data.release = mock.MagicMock(return_value=_query_returning(_retired_release()))
+    data.begin_immediate = mock.AsyncMock()
+    data.rollback = mock.AsyncMock()
+    writer = object.__new__(release.CommitteeParticipant)
+    writer._CommitteeParticipant__data = data
+    writer._CommitteeParticipant__asf_uid = "tester"
+    writer._CommitteeParticipant__committee_key = "project"
+
+    # promote_to_candidate catches AccessError internally and returns it as a string
+    result = await writer.promote_to_candidate(
+        safe.ReleaseKey("project-1.0.0"),
+        safe.RevisionNumber("00001"),
+        allowed_vote_modes=frozenset({sql.VoteMode.MANUAL}),
+    )
+    assert result is not None and "archived" in result
+
+
+@pytest.mark.asyncio
+async def test_revision_clear_quarantine_blocks_retired() -> None:
+    data = mock.MagicMock()
+    data.project = mock.MagicMock(return_value=_query_returning(_retired_project()))
+    writer = object.__new__(revision.CommitteeParticipant)
+    writer._CommitteeParticipant__data = data
+    writer._CommitteeParticipant__asf_uid = "tester"
+    writer._CommitteeParticipant__committee_key = "project"
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.clear_quarantine(
+            safe.ProjectKey("project"),
+            safe.VersionKey("1.0.0"),
+            42,
+        )
+
+
+@pytest.mark.asyncio
+async def test_revision_create_revision_with_quarantine_blocks_retired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer = object.__new__(revision.CommitteeParticipant)
+    writer._CommitteeParticipant__data = mock.MagicMock()
+    writer._CommitteeParticipant__asf_uid = "tester"
+    writer._CommitteeParticipant__committee_key = "project"
+
+    inner_data = mock.MagicMock()
+    inner_data.release = mock.MagicMock(return_value=_query_returning(_retired_release()))
+    monkeypatch.setattr(revision.db, "session", lambda: _async_context_manager(inner_data))
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.create_revision_with_quarantine(
+            safe.ProjectKey("project"),
+            safe.VersionKey("1.0.0"),
+            "tester",
+            allowed_phases=frozenset({sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_sbom_augment_blocks_retired() -> None:
+    data = mock.MagicMock()
+    data.project = mock.MagicMock(return_value=_query_returning(_retired_project()))
+    writer = object.__new__(sbom.CommitteeParticipant)
+    writer._CommitteeParticipant__data = data
+    writer._CommitteeParticipant__asf_uid = "tester"
+    writer._CommitteeParticipant__committee_key = "project"
+
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.augment_cyclonedx(
+            safe.ProjectKey("project"),
+            safe.VersionKey("1.0.0"),
+            safe.RevisionNumber("00001"),
+            safe.RelPath("artifact.tar.gz"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_vote_resolve_release_blocks_retired_after_merge() -> None:
+    data = mock.MagicMock()
+    merged = _retired_release()
+    data.merge = mock.AsyncMock(return_value=merged)
+    writer = object.__new__(vote.CommitteeMember)
+    writer._CommitteeMember__data = data
+    writer._CommitteeMember__asf_uid = "tester"
+    writer._CommitteeMember__committee_key = "project"
+
+    stub_release = SimpleNamespace(project=SimpleNamespace(status=sql.ProjectStatus.ACTIVE, key="project"))
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.resolve_release(
+            safe.ProjectKey("project"),
+            stub_release,
+            None,
+            "passed",
+            SimpleNamespace(),
+            "Chair",
+            "body",
+        )
+    data.merge.assert_awaited_once_with(stub_release)
+
+
+@pytest.mark.asyncio
+async def test_vote_send_resolution_blocks_retired() -> None:
+    writer = object.__new__(vote.CommitteeMember)
+    writer._CommitteeMember__data = mock.MagicMock()
+    writer._CommitteeMember__asf_uid = "tester"
+    writer._CommitteeMember__committee_key = "project"
+
+    rel = _retired_release()
+    with pytest.raises(storage.AccessError, match="archived"):
+        await writer.send_resolution(
+            rel,
+            "passed",
+            "body",
+            "tester",
+            "Chair",
+            SimpleNamespace(),
+        )

--- a/tests/unit/test_create_revision.py
+++ b/tests/unit/test_create_revision.py
@@ -111,6 +111,7 @@ async def test_clone_from_older_revision_skips_merge_without_intervening_change(
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_PREVIEW
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.release_policy = None
     release_key = sql.release_key("proj", "1.0")
@@ -204,6 +205,7 @@ async def test_intervening_revision_triggers_merge_and_uses_latest_parent(tmp_pa
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_PREVIEW
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.release_policy = None
     release_key = sql.release_key("proj", "1.0")
@@ -279,6 +281,7 @@ async def test_intervening_revision_with_path_provenance_verifies_sources(tmp_pa
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.release_policy = None
     release_key = sql.release_key("proj", "1.0")
@@ -400,6 +403,7 @@ async def test_modify_failed_error_propagates_and_cleans_up(tmp_path: pathlib.Pa
 
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.key = "proj"
     release.version = "1.0"
     release.latest_revision_number = "00001"
@@ -431,6 +435,7 @@ async def test_modify_path_provenance_flows_into_write_files_data(tmp_path: path
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.release_policy = None
 
@@ -579,6 +584,7 @@ async def test_v1_previous_attestable_suppresses_file_state_rows(tmp_path: pathl
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.release_policy = None
     release_key = sql.release_key("proj", "1.0")

--- a/tests/unit/test_create_revision_quarantine.py
+++ b/tests/unit/test_create_revision_quarantine.py
@@ -116,6 +116,7 @@ async def test_no_quarantine_returns_revision_when_no_archives(tmp_path: pathlib
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.project.key = "proj"
     release.version = "1.0"
@@ -172,6 +173,7 @@ async def test_phase_gate_allows_matching_phase(tmp_path: pathlib.Path):
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.release_policy = None
     release.project.key = "proj"
     release.version = "1.0"
@@ -225,6 +227,7 @@ async def test_phase_gate_allows_matching_phase(tmp_path: pathlib.Path):
 async def test_phase_gate_rejects_mismatched_phase():
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE
+    release.project.status = sql.ProjectStatus.ACTIVE
 
     mock_session = _mock_db_session(release)
     participant = _make_participant()
@@ -248,6 +251,7 @@ async def test_quarantine_branch_returns_quarantined_when_archives_detected(tmp_
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.key = "proj"
     release.version = "1.0"
     release.key = sql.release_key("proj", "1.0")
@@ -326,6 +330,7 @@ async def test_quarantine_dedup_applied_to_task_args(tmp_path: pathlib.Path):
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.project.key = "proj"
     release.version = "1.0"
     release.key = sql.release_key("proj", "1.0")
@@ -413,6 +418,7 @@ async def test_quarantine_stores_prior_revision_key_from_lock(tmp_path: pathlib.
     release = mock.MagicMock()
     release.phase = sql.ReleasePhase.RELEASE_CANDIDATE_DRAFT
     release.project = mock.MagicMock()
+    release.project.status = sql.ProjectStatus.ACTIVE
     release.key = sql.release_key("proj", "1.0")
 
     old_revision = mock.MagicMock()

--- a/tests/unit/test_quarantine_task.py
+++ b/tests/unit/test_quarantine_task.py
@@ -41,6 +41,10 @@ type TarEntry = tuple[str, str, bytes | str]
 @pytest.mark.asyncio
 async def test_clear_quarantine_raises_when_not_found():
     mock_data = mock.AsyncMock()
+    active_project = mock.MagicMock(status=sql.ProjectStatus.ACTIVE)
+    active_project_query = mock.MagicMock()
+    active_project_query.demand = mock.AsyncMock(return_value=active_project)
+    mock_data.project = mock.MagicMock(return_value=active_project_query)
     mock_query = mock.MagicMock()
     mock_query.get = mock.AsyncMock(return_value=None)
     mock_data.quarantined = mock.MagicMock(return_value=mock_query)
@@ -59,6 +63,10 @@ async def test_clear_quarantine_transitions_failed_to_acknowledged():
     quarantined_row.status = sql.QuarantineStatus.FAILED
 
     mock_data = mock.AsyncMock()
+    active_project = mock.MagicMock(status=sql.ProjectStatus.ACTIVE)
+    active_project_query = mock.MagicMock()
+    active_project_query.demand = mock.AsyncMock(return_value=active_project)
+    mock_data.project = mock.MagicMock(return_value=active_project_query)
     mock_query = mock.MagicMock()
     mock_query.get = mock.AsyncMock(return_value=quarantined_row)
     mock_data.quarantined = mock.MagicMock(return_value=mock_query)
@@ -436,6 +444,7 @@ async def test_set_tag_raises_404_when_revision_missing():
     mock_query = mock.MagicMock()
     mock_query.get = mock.AsyncMock(return_value=None)
     mock_data.revision = mock.MagicMock(return_value=mock_query)
+    _attach_active_release(mock_data)
 
     writer = _make_revision_writer(mock_data)
     with pytest.raises(base.ASFQuartException, match="Revision 00001 not found") as exc_info:
@@ -474,6 +483,7 @@ async def test_set_tag_rejects_revision_with_existing_tag():
     mock_query = mock.MagicMock()
     mock_query.get = mock.AsyncMock(return_value=revision_row)
     mock_data.revision = mock.MagicMock(return_value=mock_query)
+    _attach_active_release(mock_data)
 
     writer = _make_revision_writer(mock_data)
     with pytest.raises(storage.AccessError, match="already has a tag and cannot be changed"):
@@ -490,6 +500,7 @@ async def test_set_tag_updates_untagged_revision():
     update_result = mock.MagicMock()
     update_result.rowcount = 1
     mock_data.execute = mock.AsyncMock(return_value=update_result)
+    _attach_active_release(mock_data)
 
     writer, mock_write_as = _make_revision_writer_pair(mock_data)
     await writer.set_tag(safe.ProjectKey("proj"), safe.VersionKey("1.0"), "00001", "rc1")
@@ -606,6 +617,14 @@ async def test_validate_success_calls_promote(tmp_path: pathlib.Path):
         row, safe.ProjectKey("proj"), safe.VersionKey("1.0"), row.release.key, str(quarantine_dir)
     )
     mock_mark.assert_not_awaited()
+
+
+def _attach_active_release(mock_data: mock.AsyncMock) -> None:
+    active_project = mock.MagicMock(status=sql.ProjectStatus.ACTIVE)
+    release = mock.MagicMock(project=active_project)
+    release_query = mock.MagicMock()
+    release_query.demand = mock.AsyncMock(return_value=release)
+    mock_data.release = mock.MagicMock(return_value=release_query)
 
 
 def _make_quarantined_row() -> mock.MagicMock:

--- a/tests/unit/test_vote_end_notify.py
+++ b/tests/unit/test_vote_end_notify.py
@@ -527,7 +527,9 @@ async def test_writer_start_rejects_notify_outside_trusted_mode() -> None:
         project_key="project",
         version="1.0.0",
         key="project-1.0.0",
+        project=SimpleNamespace(status=sql.ProjectStatus.ACTIVE),
     )
+    data.release = mock.MagicMock(return_value=SimpleNamespace(demand=mock.AsyncMock(return_value=release_for_start)))
     release_writer = SimpleNamespace(
         _start_vote_no_commit=mock.AsyncMock(
             return_value=(release_for_start, 1, sql.VoteMode.EMAIL, safe.RevisionNumber("00001"))

--- a/tests/unit/test_vote_recipients.py
+++ b/tests/unit/test_vote_recipients.py
@@ -115,6 +115,7 @@ async def test_send_resolution_reuses_original_vote_recipients() -> None:
     release = SimpleNamespace(
         project=SimpleNamespace(
             key="project",
+            status=sql.ProjectStatus.ACTIVE,
             display_name="Project",
         ),
         version="1.0.0",
@@ -145,8 +146,12 @@ async def test_start_email_vote_sets_vote_seq_on_task() -> None:
     data.rollback = mock.AsyncMock()
 
     release = SimpleNamespace(
-        key="project-1.0.0",
-        project_key="project",
+        key="project-1.0.0", project_key="project", project=SimpleNamespace(status=sql.ProjectStatus.ACTIVE)
+    )
+    data.release = mock.MagicMock(
+        return_value=SimpleNamespace(
+            demand=mock.AsyncMock(return_value=release),
+        )
     )
     committee = SimpleNamespace(key="project", is_podling=False, committee_members=["chair"])
     data.project = mock.MagicMock(

--- a/tests/unit/test_vote_rendering.py
+++ b/tests/unit/test_vote_rendering.py
@@ -390,6 +390,7 @@ async def test_trusted_rendering_round_two_carryover_shows_carried_card_and_resu
         project=SimpleNamespace(
             key="myproject",
             policy_vote_comment_template="Default comment",
+            status=sql.ProjectStatus.ACTIVE,
         ),
         version="1.0.0",
     )
@@ -628,8 +629,7 @@ def _release(vote_mode: sql.VoteMode, current_vote_seq: int | None = 1) -> Simpl
         phase=sql.ReleasePhase.RELEASE_CANDIDATE,
         podling_thread_id=None,
         project=SimpleNamespace(
-            key="project",
-            policy_vote_comment_template="Default comment",
+            key="project", policy_vote_comment_template="Default comment", status=sql.ProjectStatus.ACTIVE
         ),
         version="1.0.0",
     )

--- a/tests/unit/test_vote_resolution.py
+++ b/tests/unit/test_vote_resolution.py
@@ -66,7 +66,7 @@ def test_automatic_vote_resolve_section_links_to_standard_resolve(monkeypatch: p
         vote_mode=sql.VoteMode.EMAIL,
         effective_vote_mode=sql.VoteMode.EMAIL,
         release_policy=SimpleNamespace(vote_mode=sql.VoteMode.EMAIL),
-        project=SimpleNamespace(key="project"),
+        project=SimpleNamespace(key="project", status=sql.ProjectStatus.ACTIVE),
         version="1.0.0",
     )
 
@@ -331,7 +331,7 @@ async def test_manual_resolve_page_explains_cancellation_notice_url(
     monkeypatch.setattr(sessions, "form_error_pop", _no_form_errors)
 
     release = SimpleNamespace(
-        project=SimpleNamespace(key="project"),
+        project=SimpleNamespace(key="project", status=sql.ProjectStatus.ACTIVE),
         version="1.0.0",
         short_display_name="Project 1.0.0",
     )
@@ -387,7 +387,7 @@ def test_manual_vote_resolve_section_links_to_manual_resolve(monkeypatch: pytest
         vote_mode=sql.VoteMode.MANUAL,
         effective_vote_mode=sql.VoteMode.MANUAL,
         release_policy=SimpleNamespace(vote_mode=sql.VoteMode.MANUAL),
-        project=SimpleNamespace(key="project"),
+        project=SimpleNamespace(key="project", status=sql.ProjectStatus.ACTIVE),
         version="1.0.0",
     )
 
@@ -742,6 +742,7 @@ async def test_send_resolution_cancelled_builds_cancelled_subject() -> None:
     release = SimpleNamespace(
         project=SimpleNamespace(
             key="project",
+            status=sql.ProjectStatus.ACTIVE,
             display_name="Project",
         ),
         version="1.0.0",
@@ -1238,6 +1239,7 @@ def _candidate_release(podling_thread_id: str | None = None) -> SimpleNamespace:
         ),
         project=SimpleNamespace(
             key="project",
+            status=sql.ProjectStatus.ACTIVE,
             display_name="Project",
             short_display_name="Project",
             release_policy=None,
@@ -1325,6 +1327,7 @@ def _manual_candidate_release(podling_thread_id: str | None = None) -> SimpleNam
         safe_version_key="1.0.0",
         project=SimpleNamespace(
             key="project",
+            status=sql.ProjectStatus.ACTIVE,
             display_name="Project",
             release_policy=None,
             committee=SimpleNamespace(


### PR DESCRIPTION
Thoughts on the data model?

I assume we'll create one entry in this per artifact we push to SVN, and remove them when releases are removed from SVN?