### PR TITLE
Make project display name editable from the metadata tab

### DIFF
--- a/atr/form.py
+++ b/atr/form.py
@@ -1125,7 +1125,16 @@ def _render_widget(  # noqa: C901
             attrs = {**base_attrs, "type": "text"}
             if field_value:
                 attrs["value"] = str(field_value)
-            widget = htpy.input(**attrs)
+            text_input = htpy.input(**attrs)
+            json_schema_extra = field_info.json_schema_extra or {}
+            field_prefix = json_schema_extra.get("prefix") if isinstance(json_schema_extra, dict) else None
+            if field_prefix:
+                widget = htm.div(".input-group")[
+                    htm.span(".input-group-text")[str(field_prefix)],
+                    text_input,
+                ]
+            else:
+                widget = text_input
 
         case Widget.TEXTAREA:
             json_schema_extra = field_info.json_schema_extra or {}

--- a/atr/get/projects.py
+++ b/atr/get/projects.py
@@ -719,6 +719,7 @@ async def _render_metadata_form(project: sql.Project) -> htm.Element:
             submit_label="Save",
             defaults={
                 "project_key": str(project.key),
+                "display_name": (project.name or "").removeprefix("Apache "),
                 "description": project.description or "",
                 "short_description": project.short_description or "",
                 "homepage": project.homepage or "",

--- a/atr/shared/projects.py
+++ b/atr/shared/projects.py
@@ -45,13 +45,73 @@ def _strip_whitespace(value: object) -> object:
     return value.strip() if isinstance(value, str) else value
 
 
+def _validate_display_name(val: str) -> str:
+    """Apply the Apache project display name rules. Returns the normalised value.
+
+    The form's "Apache" prefix is added automatically, so callers may submit
+    either "Example Components" or "Apache Example Components" — both yield
+    "Apache Example Components". The leading "Apache" is stripped
+    case-insensitively, so "apache example" and "APACHE Example" also work.
+    Raises ValueError on failure. Shared between AddProjectForm and
+    EditMetadataForm so the two stay in lockstep.
+    """
+    display_name = val.strip()
+    # Normalise spaces in the display name
+    display_name = re.sub(r"  +", " ", display_name)
+
+    if not display_name:
+        raise ValueError("Name is required.")
+
+    # Strip a leading "Apache" (any case) so users who type the prefix out of
+    # habit aren't punished. The canonical "Apache " is reapplied below.
+    leading_apache = re.match(r"^[Aa][Pp][Aa][Cc][Hh][Ee](?:\s+|$)", display_name)
+    if leading_apache:
+        display_name = display_name[leading_apache.end() :]
+
+    if not display_name:
+        raise ValueError("Name must have at least two words.")
+
+    display_name = f"Apache {display_name}"
+
+    display_name_words = display_name.split(" ")
+
+    # Validate display name uses correct case. Each non-Apache word must either
+    # be on the irregular-word allow-list or match one of the structural regexes.
+    # This check is sufficient: every regex restricts to alphanumerics, so any
+    # string that passes here is already character-safe by construction.
+    allowed_irregular_words = {
+        ".NET",
+        "(APR)",
+        "C++",
+        "Empire-db",
+        "Lucene.NET",
+        "Lucene.Net",
+        "Lucene.net",
+        "for",
+        "jclouds",
+    }
+    r_pascal_case = re.compile(r"^([A-Z][0-9a-z]*)+$")
+    r_camel_case = re.compile(r"^[a-z]*([A-Z][0-9a-z]*)+$")
+    r_mod_case = re.compile(r"^mod(_[0-9a-z]+)+$")
+    for display_name_word in display_name_words[1:]:
+        if display_name_word in allowed_irregular_words:
+            continue
+        is_pascal_case = r_pascal_case.match(display_name_word)
+        is_camel_case = r_camel_case.match(display_name_word)
+        is_mod_case = r_mod_case.match(display_name_word)
+        if not (is_pascal_case or is_camel_case or is_mod_case):
+            raise ValueError(f"Name word {display_name_word!r} must be in PascalCase, camelCase, or mod_ case.")
+
+    return display_name
+
+
 class AddProjectForm(form.Form):
     committee_key: safe.CommitteeKey = form.label("Committee key", widget=form.Widget.HIDDEN)
     committee_key_display: str = form.label(description="Committee key", widget=form.Widget.STATIC, default="")
     display_name: str = form.label(
         "Project name",
-        'For example, "Apache Example" or "Apache Example Components". '
-        'You must start with "Apache " and you must use title case.',
+        'For example, "Example" or "Example Components". Use title case; the "Apache" prefix is added for you.',
+        prefix="Apache",
     )
     key: Annotated[safe.ProjectKey, pydantic.BeforeValidator(_strip_whitespace)] = form.label(
         "Project key",
@@ -62,38 +122,7 @@ class AddProjectForm(form.Form):
     @pydantic.field_validator("display_name", mode="before")
     @classmethod
     def validate_display_name(cls, val: str) -> str:
-        display_name = val.strip()
-        # Normalise spaces in the display name
-        display_name = re.sub(r"  +", " ", display_name)
-
-        display_name_words = display_name.split(" ")
-
-        # Validate display name starts with "Apache"
-        if display_name_words[0] != "Apache":
-            raise ValueError("The first word in the name must be 'Apache'.")
-        # Validate display name has at least two words
-        if not display_name_words[1:]:
-            raise ValueError("Name must have at least two words.")
-
-        # Validate display name uses correct case
-        allowed_irregular_words = {".NET", "C++", "Empire-db", "Lucene.NET", "for", "jclouds"}
-        r_pascal_case = re.compile(r"^([A-Z][0-9a-z]*)+$")
-        r_camel_case = re.compile(r"^[a-z]*([A-Z][0-9a-z]*)+$")
-        r_mod_case = re.compile(r"^mod(_[0-9a-z]+)+$")
-        for display_name_word in display_name_words[1:]:
-            if display_name_word in allowed_irregular_words:
-                continue
-            is_pascal_case = r_pascal_case.match(display_name_word)
-            is_camel_case = r_camel_case.match(display_name_word)
-            is_mod_case = r_mod_case.match(display_name_word)
-            if not (is_pascal_case or is_camel_case or is_mod_case):
-                raise ValueError("Name words must be in PascalCase, camelCase, or mod_ case.")
-
-        # Validate display name is alphanumeric with spaces, dots, and plus signs
-        if not display_name.replace(" ", "").replace(".", "").replace("+", "").isalnum():
-            raise ValueError("Name must be alphanumeric and may include spaces or dots or plus signs.")
-
-        return display_name
+        return _validate_display_name(val)
 
     @pydantic.field_validator("key", mode="after")
     @classmethod
@@ -205,6 +234,11 @@ class EditCycleDatesForm(form.Form):
 class EditMetadataForm(form.Form):
     variant: EDIT_METADATA = form.value(EDIT_METADATA)
     project_key: safe.ProjectKey = form.label("Project key", widget=form.Widget.HIDDEN)
+    display_name: str = form.label(
+        "Project name",
+        'For example, "Example" or "Example Components". Use title case; the "Apache" prefix is added for you.',
+        prefix="Apache",
+    )
     description: str = form.label(description="Project description", widget=form.Widget.TEXTAREA)
     short_description: str = form.label(description="Short description", widget=form.Widget.TEXT)
     homepage: form.OptionalURL = form.label(
@@ -239,6 +273,11 @@ class EditMetadataForm(form.Form):
         widget=form.Widget.TEXTAREA,
         rows=3,
     )
+
+    @pydantic.field_validator("display_name", mode="before")
+    @classmethod
+    def validate_display_name(cls, val: str) -> str:
+        return _validate_display_name(val)
 
 
 class EditVersionSchemeForm(form.Form):

--- a/atr/storage/writers/project.py
+++ b/atr/storage/writers/project.py
@@ -285,6 +285,7 @@ class CommitteeMember(CommitteeParticipant):
         if not project:
             raise storage.AccessError(f"Project '{form.project_key}' not found.", status=404)
 
+        project.name = form.display_name
         project.description = form.description.strip() or None
         project.short_description = form.short_description.strip() or None
         project.homepage = str(form.homepage) if form.homepage else None

--- a/tests/unit/test_shared_projects.py
+++ b/tests/unit/test_shared_projects.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import atr.shared.projects as shared_projects
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Baselines — full names.
+        "Apache Example",
+        "Apache Example Components",
+        "Apache Commons Codec",
+        "Apache Maven",
+        "Apache HTTP",
+        # Suffix-only — the form's UI submits this shape after the prefix
+        # addon makes "Apache" non-editable.
+        "Example",
+        "Example Components",
+        "Commons Codec",
+        "Maven",
+        "HTTP",
+        # Whitespace normalisation.
+        "  Apache   Example  ",
+        "  Example   Components  ",
+        # Allowed irregular words.
+        "Apache Lucene.NET",
+        "Apache C++",
+        "Apache jclouds",
+        "Apache .NET",
+        ".NET",
+        "Apache CouchDB for Erlang",
+        "CouchDB for Erlang",
+        # Regression cases from #1256: real Apache projects with `-` or `_`.
+        "Apache Empire-db",
+        "Empire-db",
+        "Apache mod_jk",
+        "mod_jk",
+        "Apache mod_perl",
+        "Apache mod_python",
+        "Apache mod_ftp",
+        "Apache mod_jk Connector",
+        # Whimsy spelling variants and parenthesized abbreviations.
+        "Apache Lucene.Net",
+        "Lucene.Net",
+        "Lucene.net",
+        "Apache Portable Runtime (APR)",
+        "Portable Runtime (APR)",
+    ],
+)
+def test_validate_display_name_accepts(name: str) -> None:
+    # Should not raise.
+    shared_projects._validate_display_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",  # empty
+        "   ",  # whitespace only
+        "lowercase",  # word not in any case class
+        "Apache lowercase",  # same, with explicit prefix
+        "123Numbers",  # starts with a digit
+        "With|Pipe",  # disallowed character
+        "Has Slash/Char",  # disallowed character
+        "Has<Tag>",  # disallowed character
+    ],
+)
+def test_validate_display_name_rejects(name: str) -> None:
+    with pytest.raises(ValueError):
+        shared_projects._validate_display_name(name)
+
+
+def test_validate_display_name_returns_normalised_value() -> None:
+    assert shared_projects._validate_display_name("  Apache   Example  ") == "Apache Example"
+
+
+def test_validate_display_name_prepends_apache_when_omitted() -> None:
+    assert shared_projects._validate_display_name("Example") == "Apache Example"
+    assert shared_projects._validate_display_name("Example Components") == "Apache Example Components"
+
+
+def test_validate_display_name_accepts_explicit_prefix() -> None:
+    # Users who type "Apache" by habit shouldn't be punished.
+    assert shared_projects._validate_display_name("Apache Example") == "Apache Example"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "apache Example",
+        "APACHE Example",
+        "ApAcHe Example",
+        "apache   Example",  # extra whitespace between Apache and the rest
+        "  apache Example  ",
+    ],
+)
+def test_validate_display_name_strips_apache_case_insensitively(raw: str) -> None:
+    assert shared_projects._validate_display_name(raw) == "Apache Example"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Apache",
+        "apache",
+        "APACHE",
+        "Apache ",  # trailing space, nothing after
+    ],
+)
+def test_validate_display_name_rejects_bare_apache(raw: str) -> None:
+    with pytest.raises(ValueError):
+        shared_projects._validate_display_name(raw)


### PR DESCRIPTION
## Allow editing project display name from the metadata tab

Fixes #1254. Fixes #1256.

Adds `display_name` as an editable field on `EditMetadataForm`, alongside the existing description, homepage, etc. Committee members and admins can now change a project's display name from the metadata tab.

### Changes

- **`atr/shared/projects.py`** — extracts the display-name validation rules from `AddProjectForm.validate_display_name` into a module-level `_validate_display_name` helper, then calls it from both `AddProjectForm` and the new `display_name` field on `EditMetadataForm`. Validator is forgiving about the `Apache` prefix: users who type it out of habit (any case — `apache`, `APACHE`, `ApAcHe`) get it stripped and the canonical `Apache ` reapplied. Bare `Apache` alone is rejected; empty submission is rejected.
- **`atr/storage/writers/project.py`** — `edit_metadata` applies `form.display_name` to `project.name`.
- **`atr/get/projects.py`** — pre-populates the new field from `project.name`, stripping the `Apache ` prefix so the editable input shows just the suffix.
- **`atr/form.py`** — `Widget.TEXT` now reads an optional `prefix` from the field's `json_schema_extra` and wraps the input in a Bootstrap `input-group` with the prefix as a non-editable static addon. Generic mechanism, used here for the `Apache` prefix on the project name field in both `AddProjectForm` and `EditMetadataForm`.
- **`tests/unit/test_shared_projects.py`** — new file covering full-name input, suffix-only input (the new shape from the input-group UI), explicit Apache passthrough in any case, whitespace normalisation, empty and bare-Apache rejection, the regression cases from #1256, and the allow-list additions.

### Fixes #1256 (validator rejecting real Apache projects)

The previous final "whole string must be alphanumeric (modulo a few punctuation chars)" check was redundant with the per-word case check above it and incorrectly rejected several `allowed_irregular_words` entries. The per-word check is sufficient because every regex restricts to alphanumerics, so any string that passes is already character-safe by construction.

Also audited the validator against every TLP in the Whimsy registry. Two real Apache project names that previously failed are now covered by additions to `allowed_irregular_words`:

- `Lucene.Net` (Whimsy capitalises it differently from the existing `Lucene.NET` allow-list entry; added both `Lucene.Net` and `Lucene.net` to cover all variants)
- `(APR)` (for `Apache Portable Runtime (APR)`)

Result: 210 / 210 active TLPs in Whimsy now pass.

### On @dave2wave's data integrity concern

`Project.key` (primary key, used in every FK relationship) is untouched. `Project.name` is a non-key nullable string consumed only by the `display_name` / `short_display_name` properties. The API path `_apply_project_args_no_commit` already allowed updating `name`, so the storage layer is known-safe — this PR adds the UI surface. Historical references in already-sent emails or announcements naturally retain whatever name was in effect when they were generated.

### Not addressed here

- `description` and `short_description` are accepted by `EditMetadataForm` but not yet persisted by `edit_metadata`. Pre-existing, tracked as #1252.

### Testing

**`make unit`**: passes, including the new `tests/unit/test_shared_projects.py`.

**`make check`**: passes.

**`make e2e`**: 4 failed, 82 passed, 7 skipped, 28 errors. None of the failures or errors touch code modified by this PR — they are pre-existing on `main`. Failure pattern:

- `admin/test_revoke_ssh_keys.py` and `admin/test_revoke_tokens.py` (4 failures): flash messages not appearing after revocation actions. Admin flow only.
- `announce/*` and `vote/*` (28 errors): all the same fixture timeout — clicking "Send vote email" then waiting 30 s for navigation to `/vote/...`. Vote-start flow only.

The one e2e test that touches project pages (`projects/test_get.py::test_archive_banner_*`) passes.

Manual smoke test: edited a project display name in the dev server from the metadata tab; saw the h1 update and on projects page after save.