### PR TITLE
Fix e2e failures in main

### DIFF
--- a/atr/models/api.py
+++ b/atr/models/api.py
@@ -294,6 +294,18 @@ class ProjectGetResults(schema.Strict):
 
 
 class PolicyGetResults(schema.Strict):
+    # quart_schema.validate_response runs the response dict (produced by
+    # model_dump(mode="json")) back through this model. mode="json" serialises
+    # StrEnum values to plain strings, but schema.Strict has strict=True, which
+    # rejects strings where a LicenseCheckMode or VoteMode instance is
+    # expected. Override to allow string -> enum coercion on revalidation. We
+    # keep extra="forbid".
+    model_config = pydantic.ConfigDict(
+        extra="forbid",
+        strict=False,
+        validate_assignment=True,
+    )
+
     endpoint: Literal["/policy/get"] = schema.alias("endpoint")
     project_key: safe.ProjectKey
     policy_announce_release_subject: str

--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -910,7 +910,7 @@ This is a stable release available for production use.
 
 Downloads are available from the following URL:
 
-{{DOWNLOAD_PAGE}}
+{{DOWNLOAD_URL}}
 {{DISCLAIMER}}
 On behalf of the Apache {{COMMITTEE}} project team,
 

--- a/atr/server.py
+++ b/atr/server.py
@@ -218,6 +218,15 @@ def _app_setup_api_docs(app: base.QuartApp) -> None:
 
     app.config["QUART_SCHEMA_SWAGGER_JS_URL"] = "/static/js/min/swagger-ui-bundle.min.js"
     app.config["QUART_SCHEMA_SWAGGER_CSS_URL"] = "/static/css/swagger-ui.min.css"
+    # quart_schemas response pipeline (convert_response_return_value) calls
+    # model.model_dump() on returned Pydantic models with the default
+    # mode="python". That leaves custom types such as safe.ProjectKey as
+    # raw Python objects in the response dict, which Quarts JSON encoder
+    # then cannot serialise. Force mode="json" globally so model_dump
+    # produces JSON-friendly primitives. This matches what every endpoint
+    # actually needs on the wire, including endpoints that use SafeType
+    # subclasses (ProjectKey, ReleaseKey, etc.) and StrEnum fields.
+    app.config["QUART_SCHEMA_PYDANTIC_DUMP_OPTIONS"] = {"mode": "json"}
 
     quart_schema.QuartSchema(
         app,

--- a/atr/storage/__init__.py
+++ b/atr/storage/__init__.py
@@ -230,17 +230,16 @@ class WriteAsCommitteeMember(WriteAsCommitteeParticipant):
 
 class WriteAsFoundationAdmin(WriteAsFoundationCommitter):
     def __init__(self, write: Write, data: db.Session):
+        # __asf_uid and the asf_uid property are inherited from
+        # WriteAsFoundationCommitter. Defining our own here previously caused
+        # an AttributeError during construction: super().__init__() creates
+        # writers (notably notifications) that read write_as.asf_uid, which
+        # via MRO resolves to this class's property override, which reads
+        # _WriteAsFoundationAdmin__asf_uid, which had not yet been assigned.
         super().__init__(write, data)
-        self.__asf_uid = write.authorisation.asf_uid
         self.release = writers.release.FoundationAdmin(write, self, data)
         self.tokens = writers.tokens.FoundationAdmin(write, self, data)
         self.ssh = writers.ssh.FoundationAdmin(write, self, data)
-
-    @property
-    def asf_uid(self) -> str:
-        if self.__asf_uid is None:
-            raise AccessError("Not authorized", status=403)
-        return self.__asf_uid
 
 
 class WriteAsCommitteeAdmin(WriteAsCommitteeMember):

--- a/tests/e2e/announce/conftest.py
+++ b/tests/e2e/announce/conftest.py
@@ -80,6 +80,10 @@ def announce_context(browser: Browser) -> Generator[BrowserContext]:
     page.wait_for_load_state()
 
     page.locator("input#vote_duration").fill("0")
+    # Acknowledge every concern group raised by the checks (e.g. Rat Check)
+    # so the vote-start form accepts the submission.
+    for _box in page.locator('input[name="concerns_noted"]').all():
+        _box.check()
     page.get_by_role("button", name="Send vote email").click()
     page.wait_for_url(f"**/vote/{PROJECT_KEY}/{VERSION_KEY}")
 
@@ -219,6 +223,10 @@ def _run_release_to_finish(context: BrowserContext, page: Page, version: str, op
     page.wait_for_load_state()
 
     page.locator("input#vote_duration").fill("0")
+    # Acknowledge every concern group raised by the checks (e.g. Rat Check)
+    # so the vote-start form accepts the submission.
+    for _box in page.locator('input[name="concerns_noted"]').all():
+        _box.check()
     page.get_by_role("button", name="Send vote email").click()
     page.wait_for_url(f"**/vote/{PROJECT_KEY}/{version}")
 

--- a/tests/e2e/vote/conftest.py
+++ b/tests/e2e/vote/conftest.py
@@ -78,6 +78,13 @@ def vote_context(browser: Browser) -> Generator[BrowserContext]:
     page.locator('a[title="Start a vote on this draft"]').click()
     page.wait_for_load_state()
 
+    # Acknowledge every concern group raised by the checks (e.g. Rat Check)
+    # so the vote-start form accepts the submission. Without this, the
+    # handler returns to the form with an "acknowledge every current concern
+    # group" error and the redirect to /vote/... never happens.
+    for _box in page.locator('input[name="concerns_noted"]').all():
+        _box.check()
+
     page.get_by_role("button", name="Send vote email").click()
     page.wait_for_url(f"**/vote/{PROJECT_KEY}/{VERSION_KEY}")
 


### PR DESCRIPTION
## Summary

Fixes 32 pre-existing failures in `make e2e` on `main` (4 admin failures + 28 vote/announce timeouts). After this PR, `make e2e` finishes clean: **114 passed, 7 skipped, 0 failed, 0 errors**.

Four of the five commits are real server-side bugs that were just being masked because tests further down the suite were breaking earlier in the flow. One commit is a test-side fix to fixtures that predated a server-side concern-acknowledgement gate.

## Commits

### 0001 — Fix `WriteAsFoundationAdmin` construction-time `AttributeError`

`WriteAsFoundationAdmin.__init__` calls `super().__init__()`, which constructs writers that read `write_as.asf_uid`. Python's MRO resolves that to the *subclass's* `asf_uid` property, which reads the name-mangled `_WriteAsFoundationAdmin__asf_uid` attribute — but that attribute is set *after* `super().__init__` returns. The read raises `AttributeError` mid-construction.

Remove the redundant `__asf_uid` assignment and the `asf_uid` property override in the subclass; the parent already exposes `asf_uid` correctly.

Resolves the four `e2e/admin/test_revoke*` failures.

### 0002 — Fix `ResponseSchemaValidationError` on `GET /api/policy/get/<key>`

The handler returns `model_dump(mode="json")` (enums → strings). `quart_schema.validate_response` then re-validates that dict against `PolicyGetResults`. The base class `schema.Strict` sets `strict=True`, which refuses `str` → `StrEnum` coercion for `LicenseCheckMode` and `VoteMode`, producing a 500.

Override `PolicyGetResults.model_config` with `strict=False` (keeping `extra="forbid"`). Wire format unchanged.

### 0003 — Force JSON mode for Pydantic response dumps

After 0002, the endpoint still returned an empty body with `PydanticSerializationError: Unable to serialize unknown type: <class 'atr.models.safe.ProjectKey'>`. `quart_schema.conversion.convert_response_return_value` calls `model.model_dump()` without a mode argument (default `mode="python"`), leaving SafeType subclasses (`ProjectKey`, `ReleaseKey`) as raw Python objects that Quart's JSON encoder can't handle.

Set `app.config["QUART_SCHEMA_PYDANTIC_DUMP_OPTIONS"] = {"mode": "json"}` before `QuartSchema()` init. JSON mode respects the `to_string_ser_schema` configured on every SafeType subclass and is the correct default for an HTTP API.

Together, 0002 + 0003 also restore the 13 `e2e/report/` tests, which depend on `/api/policy/get` via the `verify_license_check_mode` fixture.

### 0004 — Acknowledge concern groups in vote/announce e2e fixtures

`vote_context`, `announce_context`, and `_run_release_to_finish` all build a release and click "Send vote email" expecting a redirect to `/vote/{project}/{version}`. The handler (`atr/post/voting.py::selected`) requires every concern group raised by the configured checks (e.g. RAT's "Rat Check") to be acknowledged via the `concerns_noted` form field before starting the vote. Without that, it returns `form_error` redirecting back to `/voting/...`, the browser sees no navigation, and Playwright times out after 30s.

Tick every `input[name="concerns_noted"]` checkbox before clicking "Send vote email" in all three fixtures. Matches the manual release-manager flow. No-op if no concerns are raised.

Resolves all 28 `e2e/vote/` + `e2e/announce/` fixture timeouts.

### 0005 — Use `DOWNLOAD_URL` not `DOWNLOAD_PAGE` in default announce template

The default announce template (`Project.policy_announce_release_default`) reads:

```
Downloads are available from the following URL:

{{DOWNLOAD_PAGE}}
```

`construct.announce_release_subject_and_body` substitutes:
- `DOWNLOAD_PAGE` ← `project.download_page or ""` (optional, often empty)
- `DOWNLOAD_URL`  ← `https://{host}/downloads/{committee}/[{path_suffix}/]` (always populated, reflects the `download_path_suffix` form field)

The line announces a URL and then substitutes the empty-by-default placeholder. The `download_path_suffix` form field and the `announce-confirm.js` body preview both feed `DOWNLOAD_URL`, so this is just the wrong variable name. One-character fix.

Resolves `e2e/announce/test_get.py::test_body_*` (3 tests).

## Test environment note

Existing test environments need a one-time `docker compose down -v` in `tests/` before running `make e2e`. The `release_policy.announce_release_template` for the test project was persisted into the SQLite state volume with the old `{{DOWNLOAD_PAGE}}` template at first startup; `policy_announce_release_template` prefers a non-empty stored value over the default, so the fix in 0005 needs a fresh volume to take effect. CI is unaffected (fresh volume every run).

## Verification

make e2e, unit, check all clean