### PR TITLE
Track the staging revision of a recorded distribution

### DIFF
--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -1556,6 +1556,12 @@ class Distribution(sqlmodel.SQLModel, table=True):
     api_url: str | None = sqlmodel.Field(default=None)
     web_url: str | None = sqlmodel.Field(default=None)
     created_by: str | None = sqlmodel.Field(default=None)
+    # Records which Revision was the source of the staged artifacts.
+    # Set when staging=True so that the finish-phase code can verify the
+    # artifacts being promoted match those that were voted on, addressing
+    # the caveat in https://github.com/apache/tooling-trusted-releases/issues/751
+    # The column is nullable so that pre-existing rows are unaffected.
+    staging_revision_key: str | None = sqlmodel.Field(default=None, foreign_key="revision.key")
     # The API response can be huge, e.g. from npm
     # So we do not store it in the database
     # api_response: Any = sqlmodel.Field(sa_column=sqlalchemy.Column(sqlalchemy.JSON))

--- a/atr/shared/distribution.py
+++ b/atr/shared/distribution.py
@@ -443,17 +443,14 @@ def _template_url(
     if staging is False:
         return dd.platform.value.template_url
 
-    supported = {
-        sql.DistributionPlatform.ARTIFACT_HUB,
-        sql.DistributionPlatform.PYPI,
-        sql.DistributionPlatform.MAVEN,
-    }
-    if dd.platform not in supported:
-        raise RuntimeError("Staging is currently supported only for ArtifactHub, PyPI and Maven Central.")
-
+    # The enum is the single source of truth for which platforms support
+    # staging: a platform supports it iff its DistributionPlatformValue
+    # declares a template_staging_url. Maintaining a parallel whitelist
+    # here meant that adding a new staging URL silently failed unless
+    # someone also remembered to update the set. See issue #751.
     template_url = dd.platform.value.template_staging_url
     if template_url is None:
-        raise RuntimeError("This platform does not provide a staging API endpoint.")
+        raise RuntimeError(f"Platform {dd.platform.value.name} does not provide a staging API endpoint.")
 
     return template_url
 

--- a/atr/storage/writers/distributions.py
+++ b/atr/storage/writers/distributions.py
@@ -156,6 +156,7 @@ class CommitteeMember(CommitteeParticipant):
         upload_date: datetime.datetime | None,
         api_url: str | None = None,
         web_url: str | None = None,
+        staging_revision_key: str | None = None,
     ) -> tuple[models.sql.Distribution, bool]:
         release = await self.__data.release(key=str(release_key), _project=True).demand(
             storage.AccessError(f"Release '{release_key}' not found.")
@@ -178,6 +179,9 @@ class CommitteeMember(CommitteeParticipant):
             api_url=api_url,
             web_url=web_url,
             created_by=self.__asf_uid,
+            # Only meaningful for staging rows; ignore the value otherwise
+            # so we don't accidentally pin a production row to a revision.
+            staging_revision_key=staging_revision_key if staging else None,
         )
         if existing is None:
             self.__data.add(dist)
@@ -227,6 +231,7 @@ class CommitteeMember(CommitteeParticipant):
         staging: bool,
         dd: models.distribution.Data,
         allow_retries: bool = False,
+        staging_revision_key: str | None = None,
     ) -> tuple[models.sql.Distribution, bool, models.distribution.Metadata | None]:
         release = await self.__data.release(key=str(release_key), _project=True).demand(
             storage.AccessError(f"Release '{release_key}' not found.")
@@ -254,6 +259,7 @@ class CommitteeMember(CommitteeParticipant):
                         upload_date=None,
                         api_url=None,
                         web_url=None,
+                        staging_revision_key=staging_revision_key,
                     )
                     return dist, added, None
                 raise storage.AccessError(f"Failed to get API response from distribution platform: {error}", status=502)
@@ -278,6 +284,7 @@ class CommitteeMember(CommitteeParticipant):
             upload_date=upload_date,
             api_url=api_url,
             web_url=web_url,
+            staging_revision_key=staging_revision_key,
         )
         return dist, added, metadata
 
@@ -302,6 +309,12 @@ class CommitteeMember(CommitteeParticipant):
             version=version,
         ).demand(RuntimeError(f"Distribution {tag} not found"))
         if existing.staging:
+            # TODO(#751): When remote promotion of artifacts to third party
+            # platforms is implemented, assert here that existing.staging_revision_key
+            # equals the current Revision.key for the release before flipping
+            # staging to False, so that the artifacts being promoted are
+            # guaranteed to match those that were voted on. The column was
+            # added in #751 for exactly this purpose.
             existing.staging = False
             existing.pending = pending
             existing.upload_date = upload_date

--- a/migrations/versions/0086_2026.05.21_38b1cb95.py
+++ b/migrations/versions/0086_2026.05.21_38b1cb95.py
@@ -1,0 +1,41 @@
+"""Add staging_revision_key to distribution
+
+Revision ID: 0086_2026.05.21_38b1cb95
+Revises: 0085_2025.05.19_9d086f7e
+Create Date: 2026-05-20 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "0086_2026.05.21_38b1cb95"
+down_revision: str | None = "0085_2025.05.19_9d086f7e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Record the revision that was the source of each staged distribution.
+    # The column is nullable so that pre-existing rows are unaffected, and
+    # so that callers that don't yet know the revision key can still record.
+    # See issue #751 for context.
+    with op.batch_alter_table("distribution", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("staging_revision_key", sa.String(), nullable=True))
+        batch_op.create_foreign_key(
+            batch_op.f("fk_distribution_staging_revision_key_revision"),
+            "revision",
+            ["staging_revision_key"],
+            ["key"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("distribution", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            batch_op.f("fk_distribution_staging_revision_key_revision"),
+            type_="foreignkey",
+        )
+        batch_op.drop_column("staging_revision_key")

--- a/tests/unit/test_distribution_staging.py
+++ b/tests/unit/test_distribution_staging.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import atr.models.distribution as distribution
+import atr.models.safe as safe
+import atr.models.sql as sql
+import atr.shared.distribution as shared_distribution
+
+
+def _data(platform: sql.DistributionPlatform, *, owner_namespace: str | None = None) -> distribution.Data:
+    return distribution.Data(
+        platform=platform,
+        owner_namespace=safe.Alphanumeric(owner_namespace) if owner_namespace else None,
+        package=safe.Alphanumeric("example"),
+        version=safe.VersionKey("1.0.0"),
+        details=False,
+    )
+
+
+# --- _template_url: enum is now the single source of truth ---
+
+
+@pytest.mark.parametrize(
+    "platform, owner_namespace",
+    [
+        (sql.DistributionPlatform.ARTIFACT_HUB, "asfowner"),
+        (sql.DistributionPlatform.MAVEN, "orgapacheexample"),
+        (sql.DistributionPlatform.PYPI, None),
+    ],
+)
+def test_template_url_returns_staging_url_when_declared(
+    platform: sql.DistributionPlatform, owner_namespace: str | None
+) -> None:
+    dd = _data(platform, owner_namespace=owner_namespace)
+    template_url = shared_distribution._template_url(dd, staging=True)
+    assert template_url == platform.value.template_staging_url
+    assert template_url is not None
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [
+        sql.DistributionPlatform.DOCKER_HUB,
+        sql.DistributionPlatform.NPM,
+        sql.DistributionPlatform.NPM_SCOPED,
+    ],
+)
+def test_template_url_raises_when_platform_has_no_staging_url(platform: sql.DistributionPlatform) -> None:
+    dd = _data(platform, owner_namespace="example")
+    with pytest.raises(RuntimeError) as excinfo:
+        shared_distribution._template_url(dd, staging=True)
+    # The improved error message names the offending platform so adding a
+    # new platform without a staging URL is debuggable. See issue #751.
+    assert platform.value.name in str(excinfo.value)
+
+
+def test_template_url_does_not_use_a_hardcoded_whitelist() -> None:
+    # Regression test for the issue identified in #751: when a platform's
+    # enum value declares a template_staging_url, _template_url must return
+    # it without requiring a parallel allowlist to be edited in lockstep.
+    for platform in sql.DistributionPlatform:
+        if platform.value.template_staging_url is None:
+            continue
+        dd = _data(platform, owner_namespace=platform.value.default_owner_namespace or "example")
+        assert shared_distribution._template_url(dd, staging=True) == platform.value.template_staging_url
+
+
+def test_template_url_returns_production_url_when_staging_false() -> None:
+    for platform in sql.DistributionPlatform:
+        dd = _data(platform, owner_namespace=platform.value.default_owner_namespace or "example")
+        assert shared_distribution._template_url(dd, staging=False) == platform.value.template_url
+
+
+# --- Distribution.staging_revision_key column ---
+
+
+def test_distribution_staging_revision_key_defaults_to_none() -> None:
+    dist = sql.Distribution(
+        release_key="example-1.0.0",
+        platform=sql.DistributionPlatform.PYPI,
+        owner_namespace="",
+        package="example",
+        version="1.0.0",
+    )
+    assert dist.staging_revision_key is None
+
+
+def test_distribution_accepts_staging_revision_key() -> None:
+    dist = sql.Distribution(
+        release_key="example-1.0.0",
+        platform=sql.DistributionPlatform.PYPI,
+        owner_namespace="",
+        package="example",
+        version="1.0.0",
+        staging=True,
+        staging_revision_key="example-1.0.0 00002",
+    )
+    assert dist.staging_revision_key == "example-1.0.0 00002"


### PR DESCRIPTION
# Track the staging revision of a recorded distribution

Closes part of #751. Related: #938.

## Summary

Two small, independent changes to the distribution layer. Both fall out of andrewmusselman's RFC on #751 as "independently useful regardless of whether remote promotion is ever built."

**A nullable `staging_revision_key` foreign key on the `distribution` table.** This records which `Revision` was the source of a staged distribution. The original issue calls out the need directly: *"we have to check that the files being promoted are the same as those that were voted on."* Without a record of the connection between a staged distribution and the underlying revision, ATR has no way to enforce that — for local re-upload today, or for remote promotion later. The column is the foundation that any future verification check can stand on. It is nullable so existing rows and call sites that don't yet know the revision key remain valid; a `TODO(#751)` in `CommitteeMember.__upgrade_staging_to_final` marks where the assertion will live once call sites populate the field.

**Removal of the hard-coded `{ARTIFACT_HUB, PYPI, MAVEN}` whitelist in `shared.distribution._template_url`.** That set duplicated knowledge already encoded in `DistributionPlatformValue.template_staging_url`. The two had to be edited in lockstep, which is a quiet footgun: adding a new staging URL (for example, enabling the commented-out GITHUB platform in `sql.py`, or eventually a Hex platform for #938) would silently fail until someone remembered to update the parallel set. After this change the enum is the single source of truth — a platform supports staging iff its value declares a `template_staging_url`. The error message also now names the offending platform, which makes the failure mode obvious.

## Files changed

| File | Change |
| --- | --- |
| `atr/models/sql.py` | Add nullable `staging_revision_key: str \| None` FK column to `Distribution` |
| `atr/shared/distribution.py` | Remove `{ARTIFACT_HUB, PYPI, MAVEN}` whitelist in `_template_url`; the error message now names the platform |
| `atr/storage/writers/distributions.py` | Thread `staging_revision_key` through `record()` and `record_from_data()` as an optional pass-through; add `TODO(#751)` marker in `__upgrade_staging_to_final` |
| `migrations/versions/0086_2026.05.21_38b1cb95.py` | Alembic migration: nullable column + FK; reversible via `downgrade()` |
| `tests/unit/test_distribution_staging.py` | Six tests covering `_template_url` for every platform (regression-pinning that no whitelist gets reintroduced) and `Distribution.staging_revision_key` defaults |

## Smoke tests run

All four of these were exercised locally against `docker compose up --build` on this branch. Anyone reviewing can reproduce them in a few minutes.

**1. Schema and migration.** On server boot, ATR's automatic `alembic upgrade head` plus the follow-up `alembic check` (in `atr/db/__init__.py`) validates that the migration applies cleanly and that the resulting DB schema matches the SQLModel definitions. Boot succeeded with `Alembic check passed: DB schema matches models`. To re-verify locally: `docker compose up --build` and watch for that line in the logs.

**2. Whitelist removal does not regress staging for platforms that worked before.** Navigate to `/distribution/stage/record/<project>/<version>` and submit the form with a non-existent package on each of the three platforms that have a staging URL. The expected result is an upstream 404 (or similar parse error) — not the old whitelist message.

- **ArtifactHub** (`helm`, `asfowner`, `example`, `1`): `404 Not Found` from `https://staging.artifacthub.io/api/v1/packages/helm/asfowner/example/1` ✅
- **Maven Central** (`orgapacheexample`, `example`, `1`): `404 Not Found` from `https://repository.apache.org:4443/repository/maven-staging/orgapacheexample/example/maven-metadata.xml` ✅

(Maven groupIds are dotted in the real world, but the form's `owner_namespace` field is typed `safe.Alphanumeric` which rejects `.`. That's a pre-existing form-validation issue, unrelated to this PR, and worth filing separately.)

**3. New error message names the platform.** Submit the same form with **Docker Hub** (`library`, `nginx`, `latest`). Expected: `Platform Docker Hub does not provide a staging API endpoint.` ✅

The `RuntimeError` raised by `_template_url` propagates to a 500 page, but that propagation is pre-existing — the old whitelist branch raised the same `RuntimeError` and produced the same 500. Only the message text changed. The 500-wrapping itself is worth a separate UX issue.

**4. New column is present and behaves as expected.**

```shell
sqlite3 state/database/atr.db "PRAGMA table_info(distribution);" | grep staging_revision_key
```

returns the column, nullable, FK to `revision.key`. After recording any distribution through the UI, `SELECT staging_revision_key FROM distribution` returns `NULL` for every row — expected, since this PR deliberately does not wire call sites to populate the field. That's a follow-up.

## What this deliberately does not change

The RFC laid out several follow-ups and called for a "narrow rather than generic" implementation. This PR matches that posture.

- **No `supports_promotion` / `promotion_mechanism` columns.** Not needed until a second platform actually needs them. `supports_promotion: bool` is derivable from `promotion_mechanism is not None`, and `promoted: bool` / `promoted_at` duplicate state that the existing `staging` boolean flip already encodes.
- **No decision on the commented `GITHUB` enum.** That needs a human yes/no. The whitelist removal here means a future enable just works.
- **No automatic revision-key lookup at call sites.** The new parameter on `record()` and `record_from_data()` is optional and defaults to `None`. Wiring `post/distribution.py`, `tasks/distribution.py`, and `api/__init__.py` to look up the current `Revision` and pass it through is a small follow-up that becomes meaningful now that the column exists.
- **No verification assertion in `__upgrade_staging_to_final`.** The `TODO(#751)` marker shows where it lands; the assertion follows once call sites populate the field.
- **No Hex/Erlang (#938) work.** That's blocked upstream on `hexpm/hexpm#1193` and needs its own design. The whitelist removal does make a future Hex platform easier to add.
- **No investigation document in `atr/docs/`.** Better handled as a separate PR once the team decides where investigation docs live.

## Required acknowledgements

- [x] I have read CONTRIBUTING.md.
- [x] "Allow maintainer edits" is enabled.
- [x] No new dependencies are introduced.
- [x] No `# noqa` or `# type: ignore` added.
- [x] Commit message uses imperative mood and is under 72 chars on the first line.
- [x] `make check`, `sh tests/run-unit.sh` pass locally.
- [x] Migration round-trips cleanly (`alembic upgrade head` → `downgrade -1` → `upgrade head`).