### PR TITLE
Clarify Maven groupId guidance

### DIFF
--- a/atr/shared/distribution.py
+++ b/atr/shared/distribution.py
@@ -70,6 +70,13 @@ import atr.util as util
 
 _SAFE_URL_SCHEMES: Final = frozenset({"http", "https"})
 _TIMEOUT: Final = aiohttp.ClientTimeout(total=60, connect=10)
+MAVEN_OWNER_NAMESPACE_HELP: Final = (
+    "For Maven Central, this is the groupId, for example org.apache.maven. "
+    "For most Apache projects it starts with org.apache.<project-name>. "
+    "You can verify the groupId by searching for the artifact on search.maven.org. "
+    "For other platforms, use the npm @scope, Docker namespace, GitHub owner, or ArtifactHub repo. "
+    "Leave blank if not used."
+)
 
 
 class DistributionError(RuntimeError): ...
@@ -133,8 +140,7 @@ class DistributionAutomateForm(form.Form):
     )
     owner_namespace: safe.OptionalOwnerNamespace = form.label(
         "Owner or Namespace",
-        "Who owns or names the package (Maven groupId, npm @scope, Docker namespace, "
-        "GitHub owner, ArtifactHub repo). Leave blank if not used.",
+        MAVEN_OWNER_NAMESPACE_HELP,
     )
     package: safe.Alphanumeric = form.label("Package")
     version: safe.VersionKey = form.label("Version")
@@ -160,8 +166,7 @@ class DistributionRecordForm(form.Form):
     platform: form.Enum[DistributionPlatform] = form.label("Platform", widget=form.Widget.SELECT)
     owner_namespace: safe.OptionalOwnerNamespace = form.label(
         "Owner or Namespace",
-        "Who owns or names the package (Maven groupId, npm @scope, Docker namespace, "
-        "GitHub owner, ArtifactHub repo). Leave blank if not used.",
+        MAVEN_OWNER_NAMESPACE_HELP,
     )
     package: safe.Alphanumeric = form.label("Package")
     version: safe.VersionKey = form.label("Version")

--- a/atr/storage/writers/distributions.py
+++ b/atr/storage/writers/distributions.py
@@ -30,6 +30,18 @@ import atr.storage.outcome as outcome
 import atr.util as util
 
 
+def _distribution_api_error(dd: models.distribution.Data, error: Exception) -> storage.AccessError:
+    if dd.platform == models.sql.DistributionPlatform.MAVEN:
+        return storage.AccessError(
+            "Failed to find the Maven artifact. Check that Owner or Namespace is the Maven groupId "
+            "(for example, org.apache.maven), and that the package artifactId and version are correct. "
+            f"You can verify Maven coordinates on https://search.maven.org. Original error: {error}",
+            status=502,
+        )
+
+    return storage.AccessError(f"Failed to get API response from distribution platform: {error}", status=502)
+
+
 class GeneralPublic:
     def __init__(
         self,
@@ -256,7 +268,7 @@ class CommitteeMember(CommitteeParticipant):
                         web_url=None,
                     )
                     return dist, added, None
-                raise storage.AccessError(f"Failed to get API response from distribution platform: {error}", status=502)
+                raise _distribution_api_error(dd, error)
         upload_date = distribution.distribution_upload_date(dd.platform, result, dd.version)
         if upload_date is None:
             raise storage.AccessError("Failed to get upload date from distribution platform", status=502)

--- a/tests/unit/test_distribution_maven_guidance.py
+++ b/tests/unit/test_distribution_maven_guidance.py
@@ -1,0 +1,31 @@
+from atr.models import distribution, sql
+from atr.shared import distribution as shared_distribution
+from atr.storage.writers import distributions
+
+
+def test_distribution_forms_explain_maven_group_id():
+    for form_cls in (
+        shared_distribution.DistributionAutomateForm,
+        shared_distribution.DistributionRecordForm,
+    ):
+        documentation = form_cls.model_fields["owner_namespace"].json_schema_extra["documentation"]
+
+        assert "Maven Central" in documentation
+        assert "groupId" in documentation
+        assert "search.maven.org" in documentation
+
+
+def test_maven_api_error_mentions_group_id():
+    data = distribution.Data(
+        platform=sql.DistributionPlatform.MAVEN,
+        owner_namespace="org.apache.maven",
+        package="maven",
+        version="1.0.0",
+        details=False,
+    )
+
+    error = distributions._distribution_api_error(data, RuntimeError("not found"))
+
+    assert error.status == 502
+    assert "Maven groupId" in str(error)
+    assert "search.maven.org" in str(error)

--- a/tests/unit/test_distribution_maven_guidance.py
+++ b/tests/unit/test_distribution_maven_guidance.py
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 from atr.models import distribution, sql
 from atr.shared import distribution as shared_distribution
 from atr.storage.writers import distributions


### PR DESCRIPTION
## Summary
- clarify Owner or Namespace help text for Maven Central groupIds
- add a Maven-specific lookup error message
- cover the guidance with unit tests

Fixes #433

## Checks
- uvx ruff check atr/shared/distribution.py atr/storage/writers/distributions.py tests/unit/test_distribution_maven_guidance.py
- uvx ruff format --check atr/shared/distribution.py atr/storage/writers/distributions.py tests/unit/test_distribution_maven_guidance.py
- py -3.13 -m py_compile atr/shared/distribution.py atr/storage/writers/distributions.py tests/unit/test_distribution_maven_guidance.py
- git diff --check

Not run: pytest, because uvloop is pulled in by hypercorn[uvloop] and does not build on Windows.