### PR TITLE
System PATs

### DIFF
--- a/atr/admin/__init__.py
+++ b/atr/admin/__init__.py
@@ -18,6 +18,8 @@
 import asyncio
 import collections
 import datetime
+import hashlib
+import ipaddress
 import json
 import os
 import pathlib
@@ -55,8 +57,10 @@ import atr.models.safe as safe
 import atr.models.sql as sql
 import atr.models.unsafe as unsafe
 import atr.models.validation as validation
+import atr.noisy as noisy
 import atr.paths as paths
 import atr.principal as principal
+import atr.shared as shared
 import atr.storage as storage
 import atr.storage.outcome as outcome
 import atr.tasks as tasks
@@ -130,6 +134,41 @@ class ValidateJwtForm(form.Form):
         if token == "":
             raise ValueError("JWT is required")
         return token
+
+
+class CreateSystemTokenForm(form.Form):
+    label: str = form.label("Label", "A name to identify this system token.")
+    allowed_ip: str = form.label(
+        "Allowed IP",
+        "Optional single IP or CIDR the token may be exchanged from. Leave blank for no restriction.",
+        default="",
+    )
+
+    @pydantic.field_validator("label", mode="after")
+    @classmethod
+    def validate_label(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Label is required")
+        if len(value) > 100:
+            raise ValueError("Label must be 100 characters or less")
+        return value
+
+    @pydantic.field_validator("allowed_ip", mode="after")
+    @classmethod
+    def validate_allowed_ip(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            return ""
+        try:
+            ipaddress.ip_network(value, strict=False)
+        except ValueError as e:
+            raise ValueError("Allowed IP must be a valid IP address or CIDR") from e
+        return value
+
+
+class RevokeSystemTokenForm(form.Form):
+    token_id: form.Int = form.label("Token ID", widget=form.Widget.HIDDEN)
 
 
 class SessionDataCommon(NamedTuple):
@@ -934,18 +973,31 @@ async def revoke_user_tokens_get(_session: web.Committer, _revoke_user_tokens: L
 
     Revoke all Personal Access Tokens for a specified user.
     """
-    token_counts: list[tuple[str, int]] = []
+    # (uid, owned_count, minted_count). owned counts user PATs the uid holds;
+    # minted counts system PATs the uid created. Both are revoked by the form
+    # below, so they need to appear in the same view.
+    token_counts: list[tuple[str, int, int]] = []
     async with db.session() as data:
-        stmt = (
-            sqlmodel.select(
-                sql.PersonalAccessToken.asfuid,
-                sqlmodel.func.count(),
-            )
+        via = sql.validate_instrumented_attribute
+        owned_stmt = (
+            sqlmodel.select(sql.PersonalAccessToken.asfuid, sqlmodel.func.count())
+            .where(via(sql.PersonalAccessToken.asfuid).is_not(None))
             .group_by(sql.PersonalAccessToken.asfuid)
-            .order_by(sql.PersonalAccessToken.asfuid)
         )
-        rows = await data.execute_query(stmt)
-        token_counts = [(row[0], row[1]) for row in rows]
+        minted_stmt = (
+            sqlmodel.select(sql.PersonalAccessToken.created_by, sqlmodel.func.count())
+            .where(via(sql.PersonalAccessToken.is_system).is_(True))
+            .group_by(sql.PersonalAccessToken.created_by)
+        )
+        owned_rows = await data.execute_query(owned_stmt)
+        minted_rows = await data.execute_query(minted_stmt)
+
+        owned = {row[0]: row[1] for row in owned_rows}
+        minted = {row[0]: row[1] for row in minted_rows}
+        token_counts = sorted(
+            ((uid, owned.get(uid, 0), minted.get(uid, 0)) for uid in (owned.keys() | minted.keys())),
+            key=lambda row: row[0],
+        )
 
     rendered_form = await form.render(
         model_cls=RevokeUserTokensForm,
@@ -981,6 +1033,99 @@ async def revoke_user_tokens_post(
         await quart.flash(f"No tokens found for {target_uid}.", "info")
 
     return await session.redirect(revoke_user_tokens_get)
+
+
+@admin.typed
+async def system_tokens_get(session: web.Committer, _system_tokens: Literal["system-tokens"]) -> str:
+    """
+    URL: GET /system-tokens
+
+    Mint and manage system tokens.
+    """
+    async with storage.write(session) as write:
+        wafa = write.as_foundation_admin()
+        tokens = await wafa.tokens.list_system_tokens()
+
+    create_form = await form.render(
+        model_cls=CreateSystemTokenForm,
+        action=util.as_url(system_tokens_create_post),
+        submit_label="Create system token",
+    )
+    rows = []
+    for token in tokens:
+        revoke_form = await form.render(
+            model_cls=RevokeSystemTokenForm,
+            action=util.as_url(system_tokens_revoke_post),
+            form_classes=".mb-0",
+            submit_classes="btn-sm btn-danger",
+            submit_label="Revoke",
+            confirm="Revoke this system token? Any JWTs issued from it stop working immediately.",
+            defaults={"token_id": token.id},
+            empty=True,
+        )
+        rows.append((token, revoke_form))
+    return await template.render(
+        "system-tokens.html",
+        create_form=create_form,
+        rows=rows,
+        format_datetime=util.format_datetime,
+    )
+
+
+@admin.typed
+async def system_tokens_create_post(
+    session: web.Committer,
+    _system_tokens_create: Literal["system-tokens/create"],
+    create_form: CreateSystemTokenForm,
+) -> web.WerkzeugResponse:
+    """
+    URL: POST /system-tokens/create
+
+    Mint a system token and show its secret once.
+    """
+    plaintext = noisy.create(shared.tokens.PAT_NOISY_SECRET_DOMAIN).decode("ascii")
+    token_hash = hashlib.sha3_256(plaintext.encode()).hexdigest()
+    created = datetime.datetime.now(datetime.UTC)
+    expires = created + datetime.timedelta(days=shared.tokens.PAT_EXPIRY_DAYS)
+    allowed_ip = create_form.allowed_ip.strip() or None
+
+    async with storage.write(session) as write:
+        wafa = write.as_foundation_admin()
+        await wafa.tokens.add_system_token(token_hash, created, expires, create_form.label, allowed_ip)
+
+    await web.flash_success(
+        htm.p[
+            htm.strong["New system token"],
+            " (",
+            htm.code[create_form.label],
+            "): ",
+            htm.code(".bg-light.border.rounded.px-1.text-break")[plaintext],
+        ],
+        htm.p(".mb-0")["Copy it now - it will not be shown again."],
+    )
+    return await session.redirect(system_tokens_get)
+
+
+@admin.typed
+async def system_tokens_revoke_post(
+    session: web.Committer,
+    _system_tokens_revoke: Literal["system-tokens/revoke"],
+    revoke_form: RevokeSystemTokenForm,
+) -> web.WerkzeugResponse:
+    """
+    URL: POST /system-tokens/revoke
+
+    Revoke a single system token.
+    """
+    async with storage.write(session) as write:
+        wafa = write.as_foundation_admin()
+        revoked = await wafa.tokens.revoke_system_token(revoke_form.token_id)
+
+    if revoked:
+        await quart.flash("System token revoked.", "success")
+    else:
+        await quart.flash("System token not found.", "info")
+    return await session.redirect(system_tokens_get)
 
 
 @admin.typed

--- a/atr/admin/templates/revoke-user-tokens.html
+++ b/atr/admin/templates/revoke-user-tokens.html
@@ -28,14 +28,18 @@
           <thead>
             <tr>
               <th>ASF UID</th>
-              <th>Token count</th>
+              <th>User PATs owned</th>
+              <th>System PATs owned</th>
+              <th>Total</th>
             </tr>
           </thead>
           <tbody>
-            {% for uid, count in token_counts %}
+            {% for uid, owned, minted in token_counts %}
               <tr>
                 <td><code>{{ uid }}</code></td>
-                <td>{{ count }}</td>
+                <td>{{ owned }}</td>
+                <td>{{ minted }}</td>
+                <td>{{ owned + minted }}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/atr/admin/templates/system-tokens.html
+++ b/atr/admin/templates/system-tokens.html
@@ -1,0 +1,66 @@
+{% extends "layouts/base-admin.html" %}
+
+{%- block title -%}System tokens ~ ATR{%- endblock title -%}
+
+{%- block description -%}Mint and manage system tokens for trusted service callers.{%- endblock description -%}
+
+{% block content %}
+  <h1>System tokens</h1>
+  <p>System tokens are admin-issued Personal Access Tokens for trusted service callers, such as the
+    <code>.asf.yaml</code> processor.</p>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      <h5 class="mb-0">Create system token</h5>
+    </div>
+    <div class="card-body">
+      {{ create_form }}
+    </div>
+  </div>
+
+  {% if rows %}
+    <div class="card">
+      <div class="card-header">
+        <h5 class="mb-0">Active system tokens</h5>
+      </div>
+      <div class="card-body">
+        <table class="table table-sm table-striped table-bordered align-middle">
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>Created by</th>
+              <th>Allowed IP</th>
+              <th>Created</th>
+              <th>Expires</th>
+              <th>Last used</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for token, revoke_form in rows %}
+              <tr>
+                <td>{{ token.label or "" }}</td>
+                <td><code>{{ token.created_by }}</code></td>
+                <td>
+                  {% if token.allowed_ip %}
+                    <code>{{ token.allowed_ip }}</code>
+                  {% else %}
+                    <span class="text-muted">Any</span>
+                  {% endif %}
+                </td>
+                <td>{{ format_datetime(token.created) }}</td>
+                <td>{{ format_datetime(token.expires) }}</td>
+                <td>
+                  {% if token.last_used %}{{ format_datetime(token.last_used) }}{% else %}Never{% endif %}
+                </td>
+                <td>{{ revoke_form }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  {% else %}
+    <div class="alert alert-info" role="alert">No system tokens have been created.</div>
+  {% endif %}
+{% endblock content %}

--- a/atr/api/__init__.py
+++ b/atr/api/__init__.py
@@ -33,6 +33,7 @@ import werkzeug.exceptions as exceptions
 import atr.blueprints.api as api
 import atr.cle as cle
 import atr.config as config
+import atr.constants as constants
 import atr.db as db
 import atr.db.interaction as interaction
 import atr.hashes as hashes
@@ -594,9 +595,15 @@ async def jwt_create(
     # Returns {"asfuid": "uid", "jwt": "jwt-token"}
     asf_uid = data.asfuid
     log.set_asf_uid(asf_uid)
-    async with storage.write(asf_uid) as write:
-        wafc = write.as_foundation_committer()
-        jwt = await wafc.tokens.issue_jwt(data.pat)
+    client_ip = quart.request.remote_addr
+    # System tokens take a service-identity context, not the LDAP-backed write().
+    if await storage.pat_is_system(data.pat):
+        async with storage.write_as_system_service(asf_uid) as wss:
+            jwt = await wss.tokens.issue_jwt(data.pat, client_ip)
+    else:
+        async with storage.write(asf_uid) as write:
+            wafc = write.as_foundation_committer()
+            jwt = await wafc.tokens.issue_jwt(data.pat, client_ip)
 
     return models.api.JwtCreateResults(
         endpoint="/jwt/create",
@@ -879,7 +886,7 @@ async def policy_update(
 
 
 @api.typed
-@api.auth.bearer
+@api.auth.system_bearer
 @quart_schema.validate_response(models.api.ProjectConfigResults, 200)
 async def project_config_upsert(
     _project_config: Literal["project/config"],
@@ -890,16 +897,17 @@ async def project_config_upsert(
 
     Upsert a project's full configuration.
 
-    Creates a project if it on by the specified key does not yet exist.
+    Creates a project under the specified key if it does not yet exist.
     Otherwise, updates all specified fields for an existing project.
 
-    The caller must be a committee member of the specified committee,
-    and for an existing project committee_key must match the current value.
+    Requires a system token. This endpoint backs the .asf.yaml processor, which
+    establishes upstream that the caller may act for the named committee. For an
+    existing project, committee_key must match the current value.
     """
     asf_uid = _jwt_asf_uid()
     try:
-        async with storage.write_as_committee_member(str(data.committee_key), asf_uid) as wacm:
-            created = await wacm.project.upsert_config(data)
+        async with storage.write_as_system_service(asf_uid) as wss:
+            created = await wss.project.upsert_config(data)
     except storage.AccessError as e:
         raise _http_exception_from_storage_access_error(e) from e
     except ValueError as e:
@@ -1648,6 +1656,7 @@ async def users_list(
     # It is not even a list of users who have logged in to ATR
     # Only those who has stored certain kinds of data:
     # PersonalAccessToken.asfuid
+    # PersonalAccessToken.created_by
     # SSHKey.asf_uid
     # PublicSigningKey.apache_uid
     # Revision.asfuid
@@ -1656,6 +1665,9 @@ async def users_list(
         via = sql.validate_instrumented_attribute
         result = await data.execute(sqlalchemy.select(via(sql.PersonalAccessToken.asfuid)).distinct())
         pat_uids = set(result.scalars().all())
+
+        result = await data.execute(sqlalchemy.select(via(sql.PersonalAccessToken.created_by)).distinct())
+        pat_creator_uids = set(result.scalars().all())
 
         result = await data.execute(sqlalchemy.select(via(sql.SSHKey.asf_uid)).distinct())
         ssh_uids = set(result.scalars().all())
@@ -1666,8 +1678,10 @@ async def users_list(
         result = await data.execute(sqlalchemy.select(via(sql.Revision.asfuid)).distinct())
         revision_uids = set(result.scalars().all())
 
-        users = pat_uids | ssh_uids | public_signing_uids | revision_uids
+        users = pat_uids | pat_creator_uids | ssh_uids | public_signing_uids | revision_uids
         users -= {None}
+        # Don't expose the system service identity as a "user".
+        users -= {constants.SYSTEM_SERVICE_UID}
     return models.api.UsersListResults(
         endpoint="/users/list",
         users=sorted(users),

--- a/atr/blueprints/api.py
+++ b/atr/blueprints/api.py
@@ -228,7 +228,7 @@ def _require_auth_level(func: Callable[..., Any], original: Callable[..., Any]) 
         raise TypeError(
             f"API route {original.__name__!r} in {original.__module__} is missing "
             "an auth decorator. Apply exactly one of @api.auth.public, "
-            "@api.auth.bearer, @api.auth.body_oidc, or @api.auth.pat. "
+            "@api.auth.bearer, @api.auth.system_bearer, @api.auth.body_oidc, or @api.auth.pat. "
             "See atr/blueprints/api_auth.py for details."
         )
     if level not in auth.VALID_LEVELS:

--- a/atr/blueprints/api_auth.py
+++ b/atr/blueprints/api_auth.py
@@ -38,11 +38,11 @@ if TYPE_CHECKING:
     import atr.models.github as github
 
 
-AuthLevel = Literal["public", "bearer", "body_oidc", "pat"]
+AuthLevel = Literal["public", "bearer", "system_bearer", "body_oidc", "pat"]
 
 AUTH_LEVEL_ATTR: Final[str] = "_api_auth_level"
 
-VALID_LEVELS: Final[frozenset[AuthLevel]] = frozenset({"public", "bearer", "body_oidc", "pat"})
+VALID_LEVELS: Final[frozenset[AuthLevel]] = frozenset({"public", "bearer", "system_bearer", "body_oidc", "pat"})
 
 _TP_CONTEXT_ATTR: Final[str] = "tp_context"
 
@@ -123,6 +123,28 @@ def pat[F: Callable[..., Awaitable[Any]]](func: F) -> F:
 def public[F: Callable[..., Awaitable[Any]]](func: F) -> F:
     """Marker for routes that require no authentication."""
     return _mark("public", func)
+
+
+def system_bearer[**P, R](
+    func: Callable[P, Coroutine[Any, Any, R]],
+) -> Callable[P, Awaitable[R]]:
+    """Require an ATR-issued Bearer JWT with system privileges (from a system PAT).
+
+    Ordinary user JWTs are rejected.
+    """
+
+    @functools.wraps(func)
+    async def checked(*args: P.args, **kwargs: P.kwargs) -> R:
+        claims = getattr(quart.g, "jwt_claims", None)
+        if not (isinstance(claims, dict) and claims.get("atr_sys")):
+            raise base.ASFQuartException("System privileges required", errorcode=403)
+        return await func(*args, **kwargs)
+
+    # require() verifies the JWT and sets quart.g.jwt_claims before checked runs.
+    wrapped = jwtoken.require(checked)
+    wrapped = quart_schema.security_scheme([{"BearerAuth": []}])(wrapped)
+    _mark("system_bearer", wrapped)
+    return wrapped
 
 
 def trusted_publisher_context() -> TrustedPublisherContext:

--- a/atr/db/__init__.py
+++ b/atr/db/__init__.py
@@ -417,9 +417,26 @@ class Session(sqlalchemy.ext.asyncio.AsyncSession):
         if commit is True:
             await self.commit()
 
-    def personal_access_token(self, token_hash: str) -> Query[sql.PersonalAccessToken]:
+    def personal_access_token(
+        self,
+        token_hash: Opt[str] = NOT_SET,
+        id: Opt[int] = NOT_SET,
+        asfuid: Opt[str] = NOT_SET,
+        created_by: Opt[str] = NOT_SET,
+        is_system: Opt[bool] = False,
+    ) -> Query[sql.PersonalAccessToken]:
+        # is_system defaults to False; pass NOT_SET to span both kinds.
         query = sqlmodel.select(sql.PersonalAccessToken)
-        query = query.where(sql.PersonalAccessToken.token_hash == token_hash)
+        if is_defined(token_hash):
+            query = query.where(sql.PersonalAccessToken.token_hash == token_hash)
+        if is_defined(id):
+            query = query.where(sql.PersonalAccessToken.id == id)
+        if is_defined(asfuid):
+            query = query.where(sql.PersonalAccessToken.asfuid == asfuid)
+        if is_defined(created_by):
+            query = query.where(sql.PersonalAccessToken.created_by == created_by)
+        if is_defined(is_system):
+            query = query.where(sql.PersonalAccessToken.is_system == is_system)
         return Query(self, query)
 
     def project(

--- a/atr/docs/authentication-security.md
+++ b/atr/docs/authentication-security.md
@@ -107,6 +107,7 @@ Committers can obtain PATs from the `/tokens` page on the ATR website. PATs have
 * **Format**: New PATs are Noisy Secrets using the `tooling.apache.org` namespace
 * **Storage**: ATR stores only SHA3-256 hashes, never the plaintext PAT
 * **Revocation**: Users can revoke their own PATs at any time; admins can revoke all PATs for any user via the admin "Revoke user tokens" page
+* **IP restriction**: A PAT may optionally be bound to a single IP or CIDR. When set, JWT issuance is refused from any other address
 * **Purpose**: PATs are used solely to obtain JWTs; they cannot be used directly for API access
 
 Only authenticated committers (signed in via ASF OAuth) can create PATs. Each user can have multiple active PATs.
@@ -146,6 +147,14 @@ Authorization: Bearer jwt_token_value
 ### Token handling
 
 The [`jwtoken`](/ref/atr/jwtoken.py) module handles JWT creation and verification. Protected API endpoints use the `@jwtoken.require` decorator, which extracts the JWT from the `Authorization` header, verifies its signature and required claims, and makes the user's ASF UID available to the handler. Verification applies a deliberate two minute leeway to the time based JWT checks to tolerate small clock skew between ATR and API clients.
+
+### System tokens
+
+Most PATs belong to a committer and are tied to their LDAP account. ATR also supports *system tokens*: PATs minted for a trusted service caller rather than a person, flagged with `is_system` in the database. A system PAT has no owning user, so its `asfuid` is null; the administrator who minted it is recorded in `created_by`, which is always set on every PAT. The JWT a system PAT mints carries a fixed service identity, `system`, which has no LDAP account. System tokens are restricted to foundation administrators; committers cannot create them from the `/tokens` page.
+
+A system token is exchanged for a JWT at `/api/jwt`, requesting the `system` identity. The resulting JWT carries an additional `atr_sys` claim and `system` as its subject. Because that identity has no LDAP account, verification skips the LDAP active check for these JWTs. It still re-validates the backing PAT on every request, so revoking the PAT immediately invalidates every JWT issued from it. Two further checks apply: a system JWT must be backed by a system PAT, and its subject must be `system`. The creating administrator and the PAT name are recorded in the audit log when the JWT is issued.
+
+Endpoints that should accept only system tokens are decorated with `@api.auth.system_bearer`, which rejects ordinary user JWTs. The committee membership check that gates committer-driven writes does not apply, so any committee authorisation for these endpoints must be established by the calling service before it reaches ATR. The only such endpoint at present is `/project/config`, which the `.asf.yaml` processor uses to create and update projects.
 
 ## GitHub Actions OIDC (Trusted Publishing)
 
@@ -302,6 +311,7 @@ Tokens must be protected by the user at all times:
 * [`blueprints/api.py`](/ref/atr/blueprints/api.py) - API wide rate limiting
 * [`api/__init__.py`](/ref/atr/api/__init__.py) - Tighter API limits for JWT creation
 * [`jwtoken.py`](/ref/atr/jwtoken.py) - JWT creation, verification, and decorators; `verify_github_oidc` implements the OIDC validation chain
+* [`blueprints/api_auth.py`](/ref/atr/blueprints/api_auth.py) - per-endpoint auth level decorators, including `system_bearer`
 * [`db/interaction.py`](/ref/atr/db/interaction.py) - `validate_trusted_jwt` implements the service account authorisation, `trusted_jwt_for_dist` implements gating based on the service account
 * [`ldap.py`](/ref/atr/ldap.py) - Account deactivation handling and credential revocation
 * [`storage/writers/tokens.py`](/ref/atr/storage/writers/tokens.py) - Token creation, deletion, and admin revocation

--- a/atr/docs/authorization-security.md
+++ b/atr/docs/authorization-security.md
@@ -146,6 +146,11 @@ Token operations apply to the authenticated user:
 * Allowed for: Anyone with a valid PAT
 * Note: This is an unauthenticated endpoint; the PAT serves as the credential
 
+**System tokens**:
+
+* Allowed for: Foundation administrators only (not committer self-service)
+* Note: System tokens are PATs for a service identity rather than a person. Endpoints that accept them (via `@api.auth.system_bearer`) apply no committee membership check, so the calling service must establish any committee authorisation upstream. See [System tokens](authentication-security#system-tokens) in the authentication guide for the mechanism.
+
 ## Implementation patterns
 
 Authorization checks in ATR follow consistent patterns.

--- a/atr/jwtoken.py
+++ b/atr/jwtoken.py
@@ -32,6 +32,7 @@ import jwt
 import quart
 
 import atr.config as config
+import atr.constants as constants
 import atr.db as db
 import atr.ldap as ldap
 import atr.log as log
@@ -68,7 +69,7 @@ def activate_signing_key(key: str) -> None:
     app.extensions[_JWT_KEY_APP_EXTENSION] = key
 
 
-def issue(uid: str, *, ttl: int = _ATR_JWT_TTL, pat_hash: str | None = None) -> str:
+def issue(uid: str, *, ttl: int = _ATR_JWT_TTL, pat_hash: str | None = None, system: bool = False) -> str:
     # audit_guidance no explicit typ header or token_type claim is added: the aud claim (_ATR_JWT_AUDIENCE)
     # already acts as an explicit token type discriminator, and ATR issues only one JWT type verified
     # by a single internal verifier — the RFC 9068 typ header is relevant to multi-issuer OAuth2 RS
@@ -85,6 +86,8 @@ def issue(uid: str, *, ttl: int = _ATR_JWT_TTL, pat_hash: str | None = None) -> 
     }
     if pat_hash:
         payload["atr_th"] = pat_hash
+    if system:
+        payload["atr_sys"] = True
     log.auth_event("jwt_issuance", uid, pat_hash=pat_hash if pat_hash else None)
     return jwt.encode(payload, _signing_key(), algorithm=_ALGORITHM)
 
@@ -143,25 +146,15 @@ async def verify(token: str) -> dict[str, Any]:
     if not isinstance(asf_uid, str):
         log.auth_failure("jwt_token", "jwt_subject_invalid")
         raise jwt.InvalidTokenError("Invalid Bearer JWT subject")
-    if not await ldap.is_active(asf_uid):
+    # System tokens have no LDAP account to check; the PAT recheck below still
+    # gates them, so revocation stays immediate.
+    is_system = bool(claims.get("atr_sys"))
+    if (not is_system) and (not await ldap.is_active(asf_uid)):
         log.auth_failure("jwt_token", "account_deleted_or_banned")
         raise base.ASFQuartException("Account is disabled", errorcode=401)
 
     # audit_guidance Revalidating PAT on each request ensures PAT deletion immediately revokes all JWTs issued therefrom
-    pat_hash = claims.get("atr_th")
-    # Not all JWTs come from PATs, so don't fail on missing atr_th
-    if pat_hash:
-        async with db.session() as data:
-            pat = await data.personal_access_token(pat_hash).get()
-            if not pat:
-                log.auth_failure("jwt_token", "pat_hash_invalid")
-                raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
-            if pat.asfuid != claims.get("sub"):
-                log.auth_failure("jwt_token", "pat_user_mismatch")
-                raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
-            if pat.expires < datetime.datetime.now(datetime.UTC):
-                log.auth_failure("jwt_token", "pat_expired")
-                raise base.ASFQuartException("Personal Access Token expired", errorcode=401)
+    await _revalidate_pat(claims, is_system)
     return claims
 
 
@@ -258,6 +251,45 @@ def _read_signing_key() -> str | None:
     if len(key) != _JWT_KEY_HEX_LENGTH:
         raise RuntimeError("JWT signing key is not 256 bits")
     return key
+
+
+async def _revalidate_pat(claims: dict[str, Any], is_system: bool) -> None:
+    pat_hash = claims.get("atr_th")
+    # A system claim with no PAT hash skipped the LDAP check and has nothing left
+    # to validate it, so reject it.
+    if is_system and (not pat_hash):
+        log.auth_failure("jwt_token", "system_without_pat")
+        raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
+    # Not all JWTs come from PATs, so don't fail on missing atr_th
+    if not pat_hash:
+        return
+    async with db.session() as data:
+        # Span both kinds so the branch below can reject a mismatch.
+        pat = await data.personal_access_token(pat_hash, is_system=db.NOT_SET).get()
+    if not pat:
+        log.auth_failure("jwt_token", "pat_hash_invalid")
+        raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
+    # A system JWT must come from a system PAT, and vice versa.
+    if pat.is_system != is_system:
+        log.auth_failure("jwt_token", "pat_system_mismatch")
+        raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
+    # Only divert to the system path when claim and row agree. Otherwise fall
+    # through to the asfuid path, which rejects a null asfuid, so a stray
+    # system PAT can't slip past silently.
+    if is_system and pat.is_system:
+        if claims.get("sub") != constants.SYSTEM_SERVICE_UID:
+            log.auth_failure("jwt_token", "system_subject_invalid")
+            raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
+    else:
+        if pat.asfuid is None:
+            log.auth_failure("jwt_token", "pat_user_missing")
+            raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
+        if pat.asfuid != claims.get("sub"):
+            log.auth_failure("jwt_token", "pat_user_mismatch")
+            raise base.ASFQuartException("Personal Access Token invalid", errorcode=401)
+    if pat.is_expired:
+        log.auth_failure("jwt_token", "pat_expired")
+        raise base.ASFQuartException("Personal Access Token expired", errorcode=401)
 
 
 def _signing_key() -> str:

--- a/atr/ldap.py
+++ b/atr/ldap.py
@@ -309,7 +309,7 @@ async def is_active(asf_uid: str) -> bool:
             return True
         if asf_uid == "test-banned":
             return False
-    if get_bind_credentials() is None:
+    if get_bind_credentials() is None and not config.is_production_mode():
         return True
     account = await account_lookup(asf_uid)
     if account is None:
@@ -384,10 +384,15 @@ async def _revoke_all_credentials(uid: str, log) -> None:
         log.auth_event("sessions_revoked", uid)
 
     async with db.session() as data:
-        token_result = await data.execute(
-            sqlmodel.select(sql.PersonalAccessToken).where(sql.PersonalAccessToken.asfuid == uid)
+        # OR on created_by so a banned admin's system PATs go too.
+        via = sql.validate_instrumented_attribute
+        stmt = sqlmodel.select(sql.PersonalAccessToken).where(
+            sqlmodel.or_(
+                via(sql.PersonalAccessToken.asfuid) == uid,
+                via(sql.PersonalAccessToken.created_by) == uid,
+            )
         )
-        tokens = list(token_result.scalars().all())
+        tokens = list((await data.execute(stmt)).scalars().all())
         for token in tokens:
             await data.delete(token)
 

--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -25,6 +25,7 @@ import copy
 import dataclasses
 import datetime
 import enum
+import ipaddress
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypeVar, assert_never, overload
 
 import pydantic
@@ -564,7 +565,11 @@ class Notification(sqlmodel.SQLModel, table=True):
 # PersonalAccessToken:
 class PersonalAccessToken(sqlmodel.SQLModel, table=True):
     id: int | None = sqlmodel.Field(default=None, primary_key=True)
-    asfuid: str = sqlmodel.Field(index=True)
+    # asfuid is the authentication subject (null for a system PAT, which has no
+    # owning user). created_by is always set, so we can still revoke all
+    # tokens a given admin minted even when asfuid is null.
+    asfuid: str | None = sqlmodel.Field(default=None, index=True)
+    created_by: str = sqlmodel.Field(index=True)
     token_hash: str = sqlmodel.Field(unique=True)
     created: datetime.datetime = sqlmodel.Field(
         default_factory=lambda: datetime.datetime.now(datetime.UTC),
@@ -573,6 +578,27 @@ class PersonalAccessToken(sqlmodel.SQLModel, table=True):
     expires: datetime.datetime = sqlmodel.Field(sa_column=sqlalchemy.Column(UTCDateTime, nullable=False))
     last_used: datetime.datetime | None = sqlmodel.Field(default=None, sa_column=sqlalchemy.Column(UTCDateTime))
     label: str | None = None
+    # System tokens are admin-minted for service callers (e.g. the .asf.yaml
+    # processor). The JWTs they mint carry the fixed system identity, skip
+    # the LDAP check, and gain system privileges.
+    is_system: bool = sqlmodel.Field(default=False)
+    # Optional single IP or CIDR the token may be exchanged from. Null means no
+    # restriction.
+    allowed_ip: str | None = None
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires < datetime.datetime.now(datetime.UTC)
+
+    def allows_ip(self, client_ip: str | None) -> bool:
+        if self.allowed_ip is None:
+            return True
+        if client_ip is None:
+            return False
+        try:
+            return ipaddress.ip_address(client_ip) in ipaddress.ip_network(self.allowed_ip, strict=False)
+        except ValueError:
+            return False
 
 
 # RevisionCounter:

--- a/atr/post/tokens.py
+++ b/atr/post/tokens.py
@@ -17,8 +17,9 @@
 
 import datetime
 import hashlib
-from typing import Final, Literal
+from typing import Literal
 
+import quart
 import quart_rate_limiter as rate_limiter
 
 import atr.blueprints.post as post
@@ -29,9 +30,6 @@ import atr.sessions as sessions
 import atr.shared as shared
 import atr.storage as storage
 import atr.web as web
-
-_EXPIRY_DAYS: Final[int] = 180
-_PAT_NOISY_SECRET_DOMAIN: Final[bytes] = b"tooling.apache.org"
 
 
 @post.typed
@@ -44,7 +42,7 @@ async def jwt_post(
     """
     async with storage.write(session) as write:
         wafc = write.as_foundation_committer()
-        jwt_token = await wafc.tokens.issue_jwt(form.pat)
+        jwt_token = await wafc.tokens.issue_jwt(form.pat, quart.request.remote_addr)
     response = web.TextResponse(jwt_token)
     response.headers["Cache-Control"] = "no-store"
     return response
@@ -67,10 +65,10 @@ async def tokens(
 
 
 async def _add_token(session: web.Committer, add_form: shared.tokens.AddTokenForm) -> web.WerkzeugResponse:
-    plaintext = noisy.create(_PAT_NOISY_SECRET_DOMAIN).decode("ascii")
+    plaintext = noisy.create(shared.tokens.PAT_NOISY_SECRET_DOMAIN).decode("ascii")
     token_hash = hashlib.sha3_256(plaintext.encode()).hexdigest()
     created = datetime.datetime.now(datetime.UTC)
-    expires = created + datetime.timedelta(days=_EXPIRY_DAYS)
+    expires = created + datetime.timedelta(days=shared.tokens.PAT_EXPIRY_DAYS)
 
     async with storage.write() as write:
         wafc = write.as_foundation_committer()

--- a/atr/shared/tokens.py
+++ b/atr/shared/tokens.py
@@ -15,11 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Annotated, Literal
+from typing import Annotated, Final, Literal
 
 import pydantic
 
 import atr.form as form
+
+PAT_EXPIRY_DAYS: Final[int] = 180
+PAT_NOISY_SECRET_DOMAIN: Final[bytes] = b"tooling.apache.org"
 
 type ADD_TOKEN = Literal["add_token"]
 type DELETE_TOKEN = Literal["delete_token"]

--- a/atr/storage/__init__.py
+++ b/atr/storage/__init__.py
@@ -271,6 +271,25 @@ class WriteAsUserService(WriteAs):
         return self.__asf_uid
 
 
+class WriteAsSystemService(WriteAs):
+    # Built directly from the service identity rather than via Authorisation,
+    # which would reject an identity with no LDAP account.
+    def __init__(self, data: db.Session, asf_uid: str):
+        asf_uid = asf_uid.strip()
+        # Only the fixed service identity is valid here; anything else means
+        # a caller has wired this up wrongly.
+        if asf_uid != constants.SYSTEM_SERVICE_UID:
+            raise AccessError("System service writes require the system service identity", status=401)
+        self.__asf_uid = asf_uid
+        self.policy = writers.policy.SystemService(self, data)
+        self.project = writers.project.SystemService(self, data)
+        self.tokens = writers.tokens.SystemService(self, data)
+
+    @property
+    def asf_uid(self) -> str:
+        return self.__asf_uid
+
+
 # TODO: Could name this WriteDispatcher
 class Write:
     # Read and Write have authenticator methods which return access outcomes
@@ -509,6 +528,13 @@ def ensure_project_active(project: sql.Project) -> None:
     raise AccessError(f"Project '{project.key}' is archived; release actions are disabled.")
 
 
+async def pat_is_system(pat_text: str) -> bool:
+    token_hash = writers.tokens.hash_pat(pat_text)
+    async with db.session() as data:
+        pat = await data.personal_access_token(token_hash, is_system=db.NOT_SET).get()
+    return bool(pat and pat.is_system)
+
+
 @contextlib.asynccontextmanager
 async def read(asf_uid: principal.UID = principal.ArgumentNone) -> AsyncGenerator[Read]:
     if asf_uid is principal.ArgumentNone:
@@ -603,6 +629,13 @@ async def write_as_system() -> AsyncGenerator[writers.release.FoundationAdmin]:
         system_write: Any = types.SimpleNamespace(authorisation=system_authorisation)
         system_write_as: Any = WriteAs()
         yield writers.release.FoundationAdmin(system_write, system_write_as, data)
+
+
+@contextlib.asynccontextmanager
+async def write_as_system_service(asf_uid: str) -> AsyncGenerator[WriteAsSystemService]:
+    async with db.session() as data:
+        wss = WriteAsSystemService(data, asf_uid)
+        yield wss
 
 
 @contextlib.asynccontextmanager

--- a/atr/storage/readers/tokens.py
+++ b/atr/storage/readers/tokens.py
@@ -46,12 +46,9 @@ class FoundationCommitter(GeneralPublic):
         if asf_uid is None:
             raise ValueError("Not authorized")
         via = sql.validate_instrumented_attribute
-        stmt = (
-            sqlmodel.select(sql.PersonalAccessToken)
-            .where(sql.PersonalAccessToken.asfuid == asf_uid)
-            .order_by(via(sql.PersonalAccessToken.created))
+        tokens = await (
+            self.__data.personal_access_token(asfuid=asf_uid).order_by(via(sql.PersonalAccessToken.created)).all()
         )
-        tokens = await self.__data.query_all(stmt)
         return [types.PersonalAccessTokenSafe.from_sql(token) for token in tokens]
 
     async def most_recent_jwt_pat(self) -> types.PersonalAccessTokenSafe | None:
@@ -64,6 +61,7 @@ class FoundationCommitter(GeneralPublic):
         stmt = (
             sqlmodel.select(sql.PersonalAccessToken)
             .where(sql.PersonalAccessToken.asfuid == asf_uid)
+            .where(via(sql.PersonalAccessToken.is_system).is_(False))
             .where(via(sql.PersonalAccessToken.last_used).is_not(None))
             .order_by(via(sql.PersonalAccessToken.last_used).desc())
             .limit(1)

--- a/atr/storage/types.py
+++ b/atr/storage/types.py
@@ -81,10 +81,13 @@ class PathInfo(schema.Strict):
 
 
 class PersonalAccessTokenSafe(schema.Strict):
-    asfuid: str
+    allowed_ip: str | None
+    asfuid: str | None
+    created_by: str
     created: datetime.datetime
     expires: datetime.datetime
     id: int
+    is_system: bool
     label: str | None
     last_used: datetime.datetime | None
 
@@ -94,9 +97,12 @@ class PersonalAccessTokenSafe(schema.Strict):
             raise ValueError("PAT must have an ID before being returned")
         return cls(
             id=token.id,
+            allowed_ip=token.allowed_ip,
             asfuid=token.asfuid,
+            created_by=token.created_by,
             created=token.created,
             expires=token.expires,
+            is_system=token.is_system,
             label=token.label,
             last_used=token.last_used,
         )

--- a/atr/storage/writers/policy.py
+++ b/atr/storage/writers/policy.py
@@ -234,45 +234,7 @@ class CommitteeMember(CommitteeParticipant):
         project_key: models.safe.ProjectKey,
         update: models.api.PolicyUpdateArgs,
     ) -> None:
-        # TODO: Ideally we would centralise the validation in this method
-        project, release_policy = await self.__get_or_create_policy(project_key)
-        excluded_fields = {"manual_vote", "project", "vote_mode"} | set(_RECIPIENT_API_FIELDS)
-        fields_to_update = update.model_fields_set - excluded_fields
-        normalised_values: dict[str, Any] = {}
-
-        self.__set_policy_vote_mode_from_api(project, release_policy, update)
-
-        for field, action in _RECIPIENT_API_FIELDS.items():
-            if field in update.model_fields_set:
-                recipients = getattr(update, field)
-                if recipients is None:
-                    _set_recipient_defaults(release_policy, action, "", [], [])
-                else:
-                    _set_recipient_defaults(
-                        release_policy,
-                        action,
-                        str(recipients.to) if recipients.to else "",
-                        [str(address) for address in recipients.cc],
-                        [str(address) for address in recipients.bcc],
-                    )
-
-        for field in fields_to_update:
-            value = getattr(update, field)
-            if (value is None) and (field not in _NULLABLE_POLICY_FIELDS):
-                raise ValueError(f"Field '{field}' does not accept null")
-            normalised_values[field] = value
-
-        if ("file_tag_mappings" in fields_to_update) and (update.file_tag_mappings is not None):
-            _validate_file_tag_mappings(update.file_tag_mappings)
-
-        if ("min_hours" in fields_to_update) and (update.min_hours is not None):
-            models.validation.validate_policy_min_hours(update.min_hours)
-
-        if fields_to_update & _TRUSTED_PUBLISHING_FIELDS:
-            normalised_values.update(_normalise_trusted_publishing_update(release_policy, normalised_values))
-
-        for field in fields_to_update:
-            setattr(release_policy, field, normalised_values[field])
+        await _apply_policy_update_no_commit(self.__data, project_key, update)
 
     async def edit_finish(self, form: shared.projects.FinishPolicyForm) -> None:
         project_key = form.project_key
@@ -374,17 +336,7 @@ class CommitteeMember(CommitteeParticipant):
     async def __get_or_create_policy(
         self, project_key: models.safe.ProjectKey
     ) -> tuple[models.sql.Project, models.sql.ReleasePolicy]:
-        project = await self.__data.project(
-            key=str(project_key), status=models.sql.ProjectStatus.ACTIVE, _release_policy=True, _committee=True
-        ).demand(storage.AccessError(f"Project {project_key} not found", status=404))
-
-        release_policy = project.release_policy
-        if release_policy is None:
-            release_policy = models.sql.ReleasePolicy(project=project)
-            project.release_policy = release_policy
-            self.__data.add(release_policy)
-
-        return project, release_policy
+        return await _get_or_create_policy(self.__data, project_key)
 
     def __set_announce_release_subject(
         self,
@@ -430,30 +382,6 @@ class CommitteeMember(CommitteeParticipant):
             release_policy.min_hours = None
         else:
             release_policy.min_hours = submitted_min_hours
-
-    def __set_policy_vote_mode_from_api(
-        self,
-        project: models.sql.Project,
-        release_policy: models.sql.ReleasePolicy,
-        update: models.api.PolicyUpdateArgs,
-    ) -> None:
-        if "vote_mode" in update.model_fields_set:
-            if update.vote_mode is None:
-                raise ValueError("Field 'vote_mode' does not accept null")
-            if (update.vote_mode == models.sql.VoteMode.MANUAL) and project.committee and project.committee.is_podling:
-                raise storage.AccessError("Manual voting is not allowed for podlings.", status=400)
-            release_policy.vote_mode = update.vote_mode
-            return
-        if "manual_vote" not in update.model_fields_set:
-            return
-        if update.manual_vote is None:
-            raise ValueError("Field 'manual_vote' does not accept null")
-        if update.manual_vote:
-            if project.committee and project.committee.is_podling:
-                raise storage.AccessError("Manual voting is not allowed for podlings.", status=400)
-            release_policy.vote_mode = models.sql.VoteMode.MANUAL
-        else:
-            release_policy.vote_mode = models.sql.VoteMode.EMAIL
 
     def __set_start_vote_subject(
         self,
@@ -504,6 +432,81 @@ class CommitteeMember(CommitteeParticipant):
             release_policy.finish_vote_template = submitted_template
 
 
+class SystemService:
+    def __init__(self, write_as: storage.WriteAsSystemService, data: db.Session):
+        self.__data = data
+
+    async def _edit_policy_no_commit(
+        self,
+        project_key: models.safe.ProjectKey,
+        update: models.api.PolicyUpdateArgs,
+    ) -> None:
+        await _apply_policy_update_no_commit(self.__data, project_key, update)
+
+
+async def _apply_policy_update_no_commit(
+    data: db.Session,
+    project_key: models.safe.ProjectKey,
+    update: models.api.PolicyUpdateArgs,
+) -> None:
+    # TODO: Ideally we would centralise the validation in this function
+    project, release_policy = await _get_or_create_policy(data, project_key)
+    excluded_fields = {"manual_vote", "project", "vote_mode"} | set(_RECIPIENT_API_FIELDS)
+    fields_to_update = update.model_fields_set - excluded_fields
+    normalised_values: dict[str, Any] = {}
+
+    _set_policy_vote_mode_from_api(project, release_policy, update)
+
+    for field, action in _RECIPIENT_API_FIELDS.items():
+        if field in update.model_fields_set:
+            recipients = getattr(update, field)
+            if recipients is None:
+                _set_recipient_defaults(release_policy, action, "", [], [])
+            else:
+                _set_recipient_defaults(
+                    release_policy,
+                    action,
+                    str(recipients.to) if recipients.to else "",
+                    [str(address) for address in recipients.cc],
+                    [str(address) for address in recipients.bcc],
+                )
+
+    for field in fields_to_update:
+        value = getattr(update, field)
+        if (value is None) and (field not in _NULLABLE_POLICY_FIELDS):
+            raise ValueError(f"Field '{field}' does not accept null")
+        normalised_values[field] = value
+
+    if ("file_tag_mappings" in fields_to_update) and (update.file_tag_mappings is not None):
+        _validate_file_tag_mappings(update.file_tag_mappings)
+
+    if ("min_hours" in fields_to_update) and (update.min_hours is not None):
+        models.validation.validate_policy_min_hours(update.min_hours)
+
+    if fields_to_update & _TRUSTED_PUBLISHING_FIELDS:
+        normalised_values.update(_normalise_trusted_publishing_update(release_policy, normalised_values))
+
+    for field in fields_to_update:
+        setattr(release_policy, field, normalised_values[field])
+
+
+async def _get_or_create_policy(
+    data: db.Session,
+    project_key: models.safe.ProjectKey,
+) -> tuple[models.sql.Project, models.sql.ReleasePolicy]:
+    project = await data.project(
+        key=str(project_key), status=models.sql.ProjectStatus.ACTIVE, _release_policy=True, _committee=True
+    ).demand(storage.AccessError(f"Project {project_key} not found", status=404))
+
+    release_policy = project.release_policy
+    if release_policy is None:
+        release_policy = models.sql.ReleasePolicy(project=project)
+        project.release_policy = release_policy
+        data.add(release_policy)
+
+    return project, release_policy
+
+
 def _normalise_text_list(values: list[str]) -> list[str]:
     return [value.strip() for value in values if value.strip()]
 
@@ -539,6 +542,30 @@ def _normalise_trusted_publishing_update(
     util.validate_trusted_publishing_constraints(github_repository_name, github_repository_branch, all_paths)
 
     return normalised_values
+
+
+def _set_policy_vote_mode_from_api(
+    project: models.sql.Project,
+    release_policy: models.sql.ReleasePolicy,
+    update: models.api.PolicyUpdateArgs,
+) -> None:
+    if "vote_mode" in update.model_fields_set:
+        if update.vote_mode is None:
+            raise ValueError("Field 'vote_mode' does not accept null")
+        if (update.vote_mode == models.sql.VoteMode.MANUAL) and project.committee and project.committee.is_podling:
+            raise storage.AccessError("Manual voting is not allowed for podlings.", status=400)
+        release_policy.vote_mode = update.vote_mode
+        return
+    if "manual_vote" not in update.model_fields_set:
+        return
+    if update.manual_vote is None:
+        raise ValueError("Field 'manual_vote' does not accept null")
+    if update.manual_vote:
+        if project.committee and project.committee.is_podling:
+            raise storage.AccessError("Manual voting is not allowed for podlings.", status=400)
+        release_policy.vote_mode = models.sql.VoteMode.MANUAL
+    else:
+        release_policy.vote_mode = models.sql.VoteMode.EMAIL
 
 
 def _set_recipient_defaults(

--- a/atr/storage/writers/project.py
+++ b/atr/storage/writers/project.py
@@ -152,7 +152,7 @@ class CommitteeMember(CommitteeParticipant):
 
     async def create(self, committee_key: safe.CommitteeKey, display_name: str, project_key: safe.ProjectKey) -> None:
         try:
-            await self._build_and_add_project_no_commit(committee_key, display_name, project_key)
+            await _build_and_add_project(self.__data, self.__asf_uid, committee_key, display_name, project_key)
             await self.__data.commit()
         except sqlalchemy.exc.IntegrityError as e:
             if (
@@ -167,53 +167,6 @@ class CommitteeMember(CommitteeParticipant):
             committee_key=str(committee_key),
             project_key=str(project_key),
         )
-
-    async def _build_and_add_project_no_commit(
-        self,
-        committee_key: safe.CommitteeKey,
-        display_name: str,
-        project_key: safe.ProjectKey,
-    ) -> sql.Project:
-        super_project = None
-        key = str(project_key)
-        # Get the base project to derive from
-        # We're allowing derivation from a retired project here
-        # TODO: Should we disallow this instead?
-        committee_projects = await self.__data.project(
-            committee_key=str(committee_key), _committee=True, _release_policy=True
-        ).all()
-        for committee_project in committee_projects:
-            if key.startswith(str(committee_project.key) + "-"):
-                if (super_project is None) or (len(str(super_project.key)) < len(str(committee_project.key))):
-                    super_project = committee_project
-
-        # Check whether the project already exists
-        if await self.__data.project(key=key).get():
-            raise storage.AccessError(f"Project {key} already exists", status=409)
-
-        now = datetime.datetime.now(datetime.UTC)
-        project = sql.Project(
-            key=key,
-            name=display_name,
-            status=sql.ProjectStatus.ACTIVE,
-            super_project_key=super_project.key if super_project else None,
-            description=super_project.description if super_project else None,
-            categories=super_project.categories if super_project else None,
-            programming_languages=super_project.programming_languages if super_project else None,
-            version_method=super_project.version_method if super_project else sql.VersionMethod.SIMPLE,
-            version_pattern=super_project.version_pattern if super_project else None,
-            cycle_match=super_project.cycle_match if super_project else None,
-            branch_template=super_project.branch_template if super_project else None,
-            committee_key=str(committee_key),
-            created=now,
-            created_by=self.__asf_uid,
-            updated=now,
-            updated_by=self.__asf_uid,
-        )
-        if super_project and super_project.release_policy:
-            project.release_policy = super_project.release_policy.duplicate()
-        self.__data.add(project)
-        return project
 
     async def archive(self, project_key: safe.ProjectKey) -> None:
         project = await self.__data.project(key=str(project_key), status=sql.ProjectStatus.ACTIVE, _releases=True).get()
@@ -350,6 +303,29 @@ class CommitteeMember(CommitteeParticipant):
             return True
         return False
 
+    def __current_categories(self, project: sql.Project) -> list[str]:
+        return (
+            [category.strip() for category in (project.categories or "").split(",") if category.strip()]
+            if project.categories
+            else []
+        )
+
+    def __current_languages(self, project: sql.Project) -> list[str]:
+        return (
+            [language.strip() for language in (project.programming_languages or "").split(",") if language.strip()]
+            if project.programming_languages
+            else []
+        )
+
+
+# No committee gate - the caller's right to act for the committee must be
+# established upstream, in the .asf.yaml feature.
+class SystemService:
+    def __init__(self, write_as: storage.WriteAsSystemService, data: db.Session):
+        self.__write_as = write_as
+        self.__data = data
+        self.__asf_uid = write_as.asf_uid
+
     async def upsert_config(
         self,
         args: api.ProjectConfigArgs,
@@ -368,7 +344,7 @@ class CommitteeMember(CommitteeParticipant):
                 )
                 await self.__write_as.policy._edit_policy_no_commit(args.project_key, policy_update)
             project.updated = datetime.datetime.now(datetime.UTC)
-            project.updated_by = "API"
+            project.updated_by = self.__asf_uid
             await self.__data.commit()
         except sqlalchemy.exc.IntegrityError as e:
             await self.__data.rollback()
@@ -406,8 +382,12 @@ class CommitteeMember(CommitteeParticipant):
             return existing, False
         if (args.project is None) or (args.project.name is None) or (not args.project.name.strip()):
             raise ValueError(f"Project '{args.project_key}' does not exist; project.name is required to create it")
-        project = await self._build_and_add_project_no_commit(
-            args.committee_key, display_name=args.project.name, project_key=args.project_key
+        project = await _build_and_add_project(
+            self.__data,
+            self.__asf_uid,
+            args.committee_key,
+            display_name=args.project.name,
+            project_key=args.project_key,
         )
         return project, True
 
@@ -451,16 +431,51 @@ class CommitteeMember(CommitteeParticipant):
         if version_scheme_fields & provided:
             await cycles.reassign_release_cycles(self.__data, project)
 
-    def __current_categories(self, project: sql.Project) -> list[str]:
-        return (
-            [category.strip() for category in (project.categories or "").split(",") if category.strip()]
-            if project.categories
-            else []
-        )
 
-    def __current_languages(self, project: sql.Project) -> list[str]:
-        return (
-            [language.strip() for language in (project.programming_languages or "").split(",") if language.strip()]
-            if project.programming_languages
-            else []
-        )
+async def _build_and_add_project(
+    data: db.Session,
+    asf_uid: str,
+    committee_key: safe.CommitteeKey,
+    display_name: str,
+    project_key: safe.ProjectKey,
+) -> sql.Project:
+    super_project = None
+    key = str(project_key)
+    # Get the base project to derive from
+    # We're allowing derivation from a retired project here
+    # TODO: Should we disallow this instead?
+    committee_projects = await data.project(
+        committee_key=str(committee_key), _committee=True, _release_policy=True
+    ).all()
+    for committee_project in committee_projects:
+        if key.startswith(str(committee_project.key) + "-"):
+            if (super_project is None) or (len(str(super_project.key)) < len(str(committee_project.key))):
+                super_project = committee_project
+
+    # Check whether the project already exists
+    if await data.project(key=key).get():
+        raise storage.AccessError(f"Project {key} already exists", status=409)
+
+    now = datetime.datetime.now(datetime.UTC)
+    project = sql.Project(
+        key=key,
+        name=display_name,
+        status=sql.ProjectStatus.ACTIVE,
+        super_project_key=super_project.key if super_project else None,
+        description=super_project.description if super_project else None,
+        categories=super_project.categories if super_project else None,
+        programming_languages=super_project.programming_languages if super_project else None,
+        version_method=super_project.version_method if super_project else sql.VersionMethod.SIMPLE,
+        version_pattern=super_project.version_pattern if super_project else None,
+        cycle_match=super_project.cycle_match if super_project else None,
+        branch_template=super_project.branch_template if super_project else None,
+        committee_key=str(committee_key),
+        created=now,
+        created_by=asf_uid,
+        updated=now,
+        updated_by=asf_uid,
+    )
+    if super_project and super_project.release_policy:
+        project.release_policy = super_project.release_policy.duplicate()
+    data.add(project)
+    return project

--- a/atr/storage/writers/tokens.py
+++ b/atr/storage/writers/tokens.py
@@ -24,7 +24,7 @@ import hashlib
 
 import sqlmodel
 
-import atr.config as config
+import atr.constants as constants
 import atr.db as db
 import atr.jwtoken as jwtoken
 import atr.ldap as ldap
@@ -66,6 +66,7 @@ class FoundationCommitter(GeneralPublic):
             raise ValueError("Label is required")
         pat = sql.PersonalAccessToken(
             asfuid=self.__asf_uid,
+            created_by=self.__asf_uid,
             token_hash=token_hash,
             created=created,
             expires=expires,
@@ -87,12 +88,7 @@ class FoundationCommitter(GeneralPublic):
     # audit_guidance PAT deletion revokes associated JWTs
     # audit_guidance JWT verification rechecks PAT existence on every API request
     async def delete_token(self, token_id: int) -> None:
-        pat: sql.PersonalAccessToken | None = await self.__data.query_one_or_none(
-            sqlmodel.select(sql.PersonalAccessToken).where(
-                sql.PersonalAccessToken.id == token_id,
-                sql.PersonalAccessToken.asfuid == self.__asf_uid,
-            )
-        )
+        pat = await self.__data.personal_access_token(id=token_id, asfuid=self.__asf_uid).get()
         if pat is not None:
             await self.__data.delete(pat)
             await self.__data.commit()
@@ -111,15 +107,10 @@ class FoundationCommitter(GeneralPublic):
             )
             await self.__write_as.mail.send(message, mail.MailFooterCategory.AUTO)
 
-    async def issue_jwt(self, pat_text: str) -> str:
-        pat_hash = hashlib.sha3_256(pat_text.encode()).hexdigest()
-        pat = await self.__data.query_one_or_none(
-            sqlmodel.select(sql.PersonalAccessToken).where(
-                sql.PersonalAccessToken.asfuid == self.__asf_uid,
-                sql.PersonalAccessToken.token_hash == pat_hash,
-            )
-        )
-        if (pat is None) or (pat.expires < datetime.datetime.now(datetime.UTC)):
+    async def issue_jwt(self, pat_text: str, client_ip: str | None) -> str:
+        pat_hash = hash_pat(pat_text)
+        pat = await self.__data.personal_access_token(pat_hash, asfuid=self.__asf_uid).get()
+        if (pat is None) or pat.is_expired or (not pat.allows_ip(client_ip)):
             log.warning(
                 "Authentication failed",
                 extra={
@@ -128,12 +119,11 @@ class FoundationCommitter(GeneralPublic):
             )
             raise storage.AccessError("Authentication failed", status=401)
 
-        # Verify account still exists in LDAP. Test mode doesn't have LDAP wired up so we skip it
-        if not config.is_test_mode():
-            account_details = await ldap.account_lookup(self.__asf_uid)
-            if (account_details is None) or ldap.is_banned(account_details):
-                log.auth_failure("jwt_issuance", "account_deleted_or_banned", self.__asf_uid)
-                raise storage.AccessError("Authentication failed", status=401)
+        # Verify account still exists in LDAP and is not banned. is_active handles test mode internally,
+        # so the explicit test-mode bypass we used to carry here is no longer needed
+        if not await ldap.is_active(self.__asf_uid):
+            log.auth_failure("jwt_issuance", "account_deleted_or_banned", self.__asf_uid)
+            raise storage.AccessError("Authentication failed", status=401)
 
         issued_jwt = jwtoken.issue(self.__asf_uid, pat_hash=pat_hash)
         log.auth_event("jwt_issued", self.__asf_uid, pat_hash=pat_hash)
@@ -200,11 +190,58 @@ class FoundationAdmin(FoundationCommitter):
             raise storage.AccessError("Not authorized", status=403)
         self.__asf_uid = asf_uid
 
-    async def revoke_all_user_tokens(self, target_asf_uid: str) -> int:
-        """Revoke all PATs for a specified user. Returns count of revoked tokens."""
-        tokens = await self.__data.query_all(
-            sqlmodel.select(sql.PersonalAccessToken).where(sql.PersonalAccessToken.asfuid == target_asf_uid)
+    async def add_system_token(
+        self,
+        token_hash: str,
+        created: datetime.datetime,
+        expires: datetime.datetime,
+        label: str,
+        allowed_ip: str | None,
+    ) -> types.PersonalAccessTokenSafe:
+        if not label:
+            raise ValueError("Label is required")
+        # asfuid stays null so a system PAT has no owning user; created_by
+        # records the minting admin so a leaver's tokens can still be revoked.
+        pat = sql.PersonalAccessToken(
+            asfuid=None,
+            created_by=self.__asf_uid,
+            token_hash=token_hash,
+            created=created,
+            expires=expires,
+            label=label,
+            is_system=True,
+            allowed_ip=allowed_ip,
         )
+        self.__data.add(pat)
+        await self.__data.commit()
+        self.__write_as.append_to_audit_log(
+            asf_uid=self.__asf_uid,
+            pat_hash=token_hash,
+            is_system=True,
+            allowed_ip=allowed_ip,
+        )
+        log.auth_event("system_pat_issuance", self.__asf_uid, pat_hash=token_hash, name=label)
+        return types.PersonalAccessTokenSafe.from_sql(pat)
+
+    async def list_system_tokens(self) -> list[types.PersonalAccessTokenSafe]:
+        tokens = await (
+            self.__data.personal_access_token(is_system=True)
+            .order_by(sql.validate_instrumented_attribute(sql.PersonalAccessToken.created))
+            .all()
+        )
+        return [types.PersonalAccessTokenSafe.from_sql(token) for token in tokens]
+
+    async def revoke_all_user_tokens(self, target_asf_uid: str) -> int:
+        """Revoke all PATs that a specified user owns or created. Returns count of revoked tokens."""
+        # OR on created_by so a user's system PATs go too.
+        via = sql.validate_instrumented_attribute
+        stmt = sqlmodel.select(sql.PersonalAccessToken).where(
+            sqlmodel.or_(
+                via(sql.PersonalAccessToken.asfuid) == target_asf_uid,
+                via(sql.PersonalAccessToken.created_by) == target_asf_uid,
+            )
+        )
+        tokens = await self.__data.query_all(stmt)
         count = len(tokens)
         for token in tokens:
             await self.__data.delete(token)
@@ -226,6 +263,21 @@ class FoundationAdmin(FoundationCommitter):
             await self.__write_as.mail.send(message, mail.MailFooterCategory.AUTO)
         return count
 
+    async def revoke_system_token(self, token_id: int) -> bool:
+        pat = await self.__data.personal_access_token(id=token_id, is_system=True).get()
+        if pat is None:
+            return False
+        await self.__data.delete(pat)
+        await self.__data.commit()
+        self.__write_as.append_to_audit_log(
+            asf_uid=self.__asf_uid,
+            pat_hash=pat.token_hash,
+            token_id=token_id,
+            is_system=True,
+        )
+        log.auth_event("system_pat_revoke", self.__asf_uid, pat_hash=pat.token_hash, name=pat.label)
+        return True
+
     async def rotate_jwt_signing_key(self) -> None:
         key = await asyncio.to_thread(jwtoken.write_new_signing_key)
         log.auth_event("jwt_key_rotation", self.__asf_uid)
@@ -234,3 +286,47 @@ class FoundationAdmin(FoundationCommitter):
             asf_uid=self.__asf_uid,
             action="rotate_jwt_signing_key",
         )
+
+
+class SystemService:
+    def __init__(self, write_as: storage.WriteAsSystemService, data: db.Session):
+        self.__write_as = write_as
+        self.__data = data
+        self.__asf_uid = write_as.asf_uid
+
+    async def issue_jwt(self, pat_text: str, client_ip: str | None) -> str:
+        # No asfuid filter; a system PAT has no owning user.
+        pat_hash = hash_pat(pat_text)
+        pat = await self.__data.personal_access_token(pat_hash, is_system=True).get()
+        # No LDAP check; the is_system match and fixed service identity are the gate.
+        if (
+            (pat is None)
+            or (self.__asf_uid != constants.SYSTEM_SERVICE_UID)
+            or pat.is_expired
+            or (not pat.allows_ip(client_ip))
+        ):
+            log.warning(
+                "Authentication failed",
+                extra={
+                    "reason": "invalid_or_expired_system_pat",
+                },
+            )
+            raise storage.AccessError("Authentication failed", status=401)
+
+        issued_jwt = jwtoken.issue(constants.SYSTEM_SERVICE_UID, pat_hash=pat_hash, system=True)
+        log.auth_event(
+            "jwt_issued", constants.SYSTEM_SERVICE_UID, pat_hash=pat_hash, pat_owner=pat.created_by, name=pat.label
+        )
+        pat.last_used = datetime.datetime.now(datetime.UTC)
+        await self.__data.commit()
+        self.__write_as.append_to_audit_log(
+            asf_uid=constants.SYSTEM_SERVICE_UID,
+            pat_hash=pat_hash,
+            pat_owner=pat.created_by,
+            name=pat.label,
+        )
+        return issued_jwt
+
+
+def hash_pat(pat_text: str) -> str:
+    return hashlib.sha3_256(pat_text.encode()).hexdigest()

--- a/atr/templates/includes/topnav.html
+++ b/atr/templates/includes/topnav.html
@@ -232,6 +232,11 @@
               </li>
               <li>
                 <a class="dropdown-item"
+                   href="{{ as_url(admin.system_tokens_get) }}"
+                   {% if request.endpoint == 'atr_admin_system_tokens_get' %}class="active"{% endif %}><i class="bi bi-key"></i> System tokens</a>
+              </li>
+              <li>
+                <a class="dropdown-item"
                    href="{{ as_url(admin.revoke_user_ssh_keys_get) }}"
                    {% if request.endpoint == 'atr_admin_revoke_user_ssh_keys_get' %}class="active"{% endif %}><i class="bi bi-shield-x"></i> Revoke user SSH keys</a>
               </li>

--- a/migrations/versions/0091_2026.06.01_383a2b3d.py
+++ b/migrations/versions/0091_2026.06.01_383a2b3d.py
@@ -1,0 +1,50 @@
+"""Add system PAT columns to personal access tokens
+
+Revision ID: 0091_2026.06.01_383a2b3d
+Revises: 0090_2026.05.29_a13b8c92
+Create Date: 2026-06-01 09:24:31.378879+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "0091_2026.06.01_383a2b3d"
+down_revision: str | None = "0090_2026.05.29_a13b8c92"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Backfill created_by from asfuid for existing rows; all of them predate
+    # system PATs, so they are user PATs and the two columns coincide.
+    with op.batch_alter_table("personalaccesstoken", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("is_system", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+        batch_op.add_column(
+            sa.Column("allowed_ip", sa.String(), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column("created_by", sa.String(), nullable=True),
+        )
+
+    op.execute("UPDATE personalaccesstoken SET created_by = asfuid WHERE created_by IS NULL")
+
+    with op.batch_alter_table("personalaccesstoken", schema=None) as batch_op:
+        batch_op.alter_column("created_by", existing_type=sa.String(), nullable=False)
+        batch_op.alter_column("asfuid", existing_type=sa.String(), nullable=True)
+        batch_op.create_index("ix_personalaccesstoken_created_by", ["created_by"], unique=False)
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM personalaccesstoken WHERE asfuid IS NULL")
+
+    with op.batch_alter_table("personalaccesstoken", schema=None) as batch_op:
+        batch_op.drop_index("ix_personalaccesstoken_created_by")
+        batch_op.alter_column("asfuid", existing_type=sa.String(), nullable=False)
+        batch_op.drop_column("created_by")
+        batch_op.drop_column("allowed_ip")
+        batch_op.drop_column("is_system")

--- a/tests/e2e/projects/test_asf_yaml_roundtrip.py
+++ b/tests/e2e/projects/test_asf_yaml_roundtrip.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Final
 import e2e.helpers as helpers
 import pytest
 import strictyaml
-from playwright.sync_api import expect
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -90,7 +89,7 @@ def roundtrip_context(browser: Browser) -> Generator[BrowserContext]:
     context = browser.new_context(ignore_https_errors=True)
     page = context.new_page()
     helpers.log_in(page)
-    _import_project(page.request, _mint_pat_and_jwt(page))
+    _import_project(page.request, _mint_system_jwt(page))
     page.close()
     yield context
     cleanup = context.new_page()
@@ -144,14 +143,22 @@ def _import_project(request: APIRequestContext, jwt: str) -> None:
         raise RuntimeError(f"Import via /api/project/config failed ({response.status}): {response.text()}")
 
 
-def _mint_pat_and_jwt(page: Page) -> str:
-    helpers.visit(page, "/tokens")
+def _mint_system_jwt(page: Page) -> str:
+    # The asfyaml import is a system operation, so we mint a system PAT from the admin
+    # page and exchange it at jwt/create. That endpoint spots the system PAT and hands
+    # back a JWT carrying the atr_sys claim - the /tokens UI flow only issues user JWTs.
+    helpers.visit(page, "/admin/system-tokens")
     page.locator('input[name="label"]').fill("e2e-asfyaml-roundtrip")
-    page.get_by_role("button", name="Generate token").click()
+    page.get_by_role("button", name="Create system token").click()
     page.wait_for_load_state()
-    pat = page.locator(".flash-success code").first.inner_text().strip()
+    # The label and the secret both render as <code>; the secret is the one with text-break.
+    system_pat = page.locator(".flash-success code.text-break").inner_text().strip()
 
-    page.locator('#issue-jwt-form input[name="pat"]').fill(pat)
-    page.get_by_role("button", name="Generate JWT").click()
-    expect(page.locator("#jwt-container")).to_be_visible()
-    return page.locator("#jwt-output").inner_text().strip()
+    response = page.request.post(
+        f"{_BASE_URL}/api/jwt/create",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps({"asfuid": SYSTEM_SERVICE_UID, "pat": system_pat}),
+    )
+    if not response.ok:
+        raise RuntimeError(f"System JWT creation via /api/jwt/create failed ({response.status}): {response.text()}")
+    return response.json()["jwt"]

--- a/tests/e2e/projects/test_asf_yaml_roundtrip.py
+++ b/tests/e2e/projects/test_asf_yaml_roundtrip.py
@@ -36,6 +36,11 @@ _BASE_URL: Final[str] = os.environ.get("ATR_BASE_URL", "https://localhost.apache
 PROJECT_KEY: Final[str] = "test-asfyaml"
 EXPORT_URL: Final[str] = f"/project/yaml/{PROJECT_KEY}"
 
+# The asfyaml import endpoint is gated to system PATs, so we authenticate as the
+# system service. This uid must match constants.SYSTEM_SERVICE_UID server-side -
+# the system JWT issuer rejects any other identity.
+SYSTEM_SERVICE_UID: Final[str] = "system"
+
 # The .asf.yaml project block we import, then expect to get back unchanged on export.
 # It mirrors the inbound schema from infrastructure-asfyaml exactly, so a faithful
 # round-trip should reproduce it byte-for-byte once parsed.

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -282,11 +282,14 @@ def _mock_db_session(token_items: list | None = None, ssh_key_items: list | None
 
     # execute() is called twice: first for tokens, then for SSH keys
     # Each result needs .scalars().all() to return the items
-    token_result = mock.MagicMock()
-    token_result.scalars.return_value.all.return_value = token_items or []
+    pat_query = mock.MagicMock()
+    pat_query.all = mock.AsyncMock(return_value=token_items or [])
+    mock_data.personal_access_token = mock.MagicMock(return_value=pat_query)
+
+    # execute() is now called only for SSH keys.
     ssh_result = mock.MagicMock()
     ssh_result.scalars.return_value.all.return_value = ssh_key_items or []
-    mock_data.execute = mock.AsyncMock(side_effect=[token_result, ssh_result])
+    mock_data.execute = mock.AsyncMock(return_value=ssh_result)
 
     mock_session_ctx = mock.AsyncMock()
     mock_session_ctx.__aenter__ = mock.AsyncMock(return_value=mock_data)

--- a/tests/unit/test_tokens_safe.py
+++ b/tests/unit/test_tokens_safe.py
@@ -18,9 +18,12 @@
 import datetime
 import unittest.mock as mock
 
+import asfquart.base as base
 import jwt
 import pytest
 
+import atr.constants as constants
+import atr.db as db
 import atr.jwtoken as jwtoken
 import atr.models.sql as sql
 import atr.storage.readers.tokens
@@ -38,13 +41,54 @@ class FakeRead:
         self.authorisation = FakeAuthorisation(asf_uid)
 
 
+class FakeQuery:
+    """Mimics db.Query: sync order_by chains, async all/get terminate."""
+
+    def __init__(self, tokens: list[sql.PersonalAccessToken]):
+        self._tokens = tokens
+
+    def order_by(self, *_args: object) -> "FakeQuery":
+        return self
+
+    async def all(self) -> list[sql.PersonalAccessToken]:
+        return self._tokens
+
+    async def get(self) -> sql.PersonalAccessToken | None:
+        return self._tokens[0] if self._tokens else None
+
+
+def _apply_pat_filters(
+    tokens: list[sql.PersonalAccessToken],
+    token_hash: object = db.NOT_SET,
+    id: object = db.NOT_SET,
+    asfuid: object = db.NOT_SET,
+    created_by: object = db.NOT_SET,
+    is_system: object = False,
+) -> list[sql.PersonalAccessToken]:
+    # Default is_system=False mirrors db.Session.personal_access_token.
+    result = list(tokens)
+    if db.is_defined(token_hash):
+        result = [t for t in result if t.token_hash == token_hash]
+    if db.is_defined(id):
+        result = [t for t in result if t.id == id]
+    if db.is_defined(asfuid):
+        result = [t for t in result if t.asfuid == asfuid]
+    if db.is_defined(created_by):
+        result = [t for t in result if t.created_by == created_by]
+    if db.is_defined(is_system):
+        result = [t for t in result if t.is_system == is_system]
+    return result
+
+
 class FakeReadData:
     def __init__(self, tokens: list[sql.PersonalAccessToken], most_recent: sql.PersonalAccessToken | None):
         self._tokens = tokens
         self._most_recent = most_recent
 
-    async def query_all(self, _stmt):
-        return self._tokens
+    def personal_access_token(self, *args: object, **kwargs: object) -> FakeQuery:
+        if args:
+            kwargs.setdefault("token_hash", args[0])
+        return FakeQuery(_apply_pat_filters(self._tokens, **kwargs))
 
     async def query_one_or_none(self, _stmt):
         return self._most_recent
@@ -59,25 +103,57 @@ class FakeWriteAs:
     def __init__(self):
         self.mail = mock.MagicMock()
         self.mail.send = mock.AsyncMock(return_value=("mid", []))
+        self.append_to_audit_log = mock.MagicMock()
 
 
 class FakeWriteData:
-    def __init__(self):
+    def __init__(self, tokens: list[sql.PersonalAccessToken] | None = None):
         self._added: sql.PersonalAccessToken | None = None
+        self._tokens = tokens if tokens is not None else []
+        self.deleted: list[sql.PersonalAccessToken] = []
 
     def add(self, pat: sql.PersonalAccessToken) -> None:
         self._added = pat
+
+    async def delete(self, pat: sql.PersonalAccessToken) -> None:
+        self.deleted.append(pat)
 
     async def commit(self) -> None:
         if self._added is None:
             return
         self._added.id = 101
 
+    def personal_access_token(self, *args: object, **kwargs: object) -> FakeQuery:
+        if args:
+            kwargs.setdefault("token_hash", args[0])
+        return FakeQuery(_apply_pat_filters(self._tokens, **kwargs))
+
+
+def _make_pat(
+    *,
+    expires: datetime.datetime | None = None,
+    allowed_ip: str | None = None,
+    is_system: bool = False,
+) -> sql.PersonalAccessToken:
+    now = datetime.datetime.now(tz=datetime.UTC)
+    # System PATs have no owning user; user PATs have asfuid equal to created_by.
+    asfuid = None if is_system else "test"
+    return sql.PersonalAccessToken(
+        asfuid=asfuid,
+        created_by="test",
+        token_hash="0" * 64,
+        created=now,
+        expires=expires if expires is not None else now + datetime.timedelta(days=1),
+        allowed_ip=allowed_ip,
+        is_system=is_system,
+    )
+
 
 def test_personal_access_token_safe_excludes_token_hash() -> None:
     token = sql.PersonalAccessToken(
         id=5,
         asfuid="test",
+        created_by="test",
         token_hash="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         created=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
         expires=datetime.datetime(2026, 6, 1, tzinfo=datetime.UTC),
@@ -89,6 +165,8 @@ def test_personal_access_token_safe_excludes_token_hash() -> None:
 
     assert safe.id == 5
     assert safe.asfuid == "test"
+    assert safe.created_by == "test"
+    assert safe.is_system is False
     assert "token_hash" not in safe.model_dump()
     assert not hasattr(safe, "token_hash")
 
@@ -99,6 +177,7 @@ async def test_reader_pat_methods_return_safe_tokens() -> None:
     token = sql.PersonalAccessToken(
         id=7,
         asfuid="test",
+        created_by="test",
         token_hash="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         created=created,
         expires=created + datetime.timedelta(days=180),
@@ -118,6 +197,22 @@ async def test_reader_pat_methods_return_safe_tokens() -> None:
     assert isinstance(most_recent, types.PersonalAccessTokenSafe)
     assert most_recent is not None
     assert "token_hash" not in most_recent.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_reader_hides_system_pats_from_user_listing() -> None:
+    user_token = _make_pat()
+    user_token.id = 11
+    system_token = _make_pat(is_system=True)
+    system_token.id = 12
+
+    read = FakeRead("test")
+    data = FakeReadData([user_token, system_token], None)
+    reader = atr.storage.readers.tokens.FoundationCommitter(read, mock.MagicMock(), data)
+
+    tokens_list = await reader.own_personal_access_tokens()
+
+    assert [t.id for t in tokens_list] == [11]
 
 
 @pytest.mark.asyncio
@@ -161,3 +256,161 @@ async def test_writer_add_token_returns_safe_token() -> None:
     assert isinstance(safe, types.PersonalAccessTokenSafe)
     assert safe.id == 101
     assert "token_hash" not in safe.model_dump()
+
+
+def test_is_expired() -> None:
+    now = datetime.datetime.now(tz=datetime.UTC)
+    assert _make_pat(expires=now + datetime.timedelta(days=1)).is_expired is False
+    assert _make_pat(expires=now - datetime.timedelta(days=1)).is_expired is True
+
+
+def test_allows_ip() -> None:
+    unrestricted = _make_pat(allowed_ip=None)
+    assert unrestricted.allows_ip("1.2.3.4") is True
+    assert unrestricted.allows_ip(None) is True
+
+    single = _make_pat(allowed_ip="1.2.3.4")
+    assert single.allows_ip("1.2.3.4") is True
+    assert single.allows_ip("1.2.3.5") is False
+    assert single.allows_ip(None) is False
+    assert single.allows_ip("not-an-ip") is False
+
+    cidr = _make_pat(allowed_ip="10.0.0.0/8")
+    assert cidr.allows_ip("10.1.2.3") is True
+    assert cidr.allows_ip("11.0.0.1") is False
+
+
+@pytest.mark.asyncio
+async def test_writer_add_system_token() -> None:
+    created = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    write = FakeWrite("admin")
+    write_as = FakeWriteAs()
+    data = FakeWriteData()
+    writer = atr.storage.writers.tokens.FoundationAdmin(write, write_as, data)
+
+    safe = await writer.add_system_token(
+        token_hash="0" * 64,
+        created=created,
+        expires=created + datetime.timedelta(days=180),
+        label="asfyaml",
+        allowed_ip="10.0.0.0/8",
+    )
+
+    assert isinstance(safe, types.PersonalAccessTokenSafe)
+    assert safe.id == 101
+    # System PATs have no owning user; created_by records the minting admin.
+    assert safe.asfuid is None
+    assert safe.created_by == "admin"
+    assert safe.is_system is True
+    assert safe.allowed_ip == "10.0.0.0/8"
+    write_as.append_to_audit_log.assert_called_once()
+    audit_kwargs = write_as.append_to_audit_log.call_args.kwargs
+    assert audit_kwargs["is_system"] is True
+    assert audit_kwargs["allowed_ip"] == "10.0.0.0/8"
+
+
+@pytest.mark.asyncio
+async def test_writer_revoke_system_token() -> None:
+    token = _make_pat(is_system=True)
+    token.id = 5
+    write = FakeWrite("admin")
+    data = FakeWriteData(tokens=[token])
+    writer = atr.storage.writers.tokens.FoundationAdmin(write, FakeWriteAs(), data)
+
+    assert await writer.revoke_system_token(5) is True
+    assert data.deleted == [token]
+
+    empty = FakeWriteData(tokens=[])
+    writer_empty = atr.storage.writers.tokens.FoundationAdmin(write, FakeWriteAs(), empty)
+    assert await writer_empty.revoke_system_token(999) is False
+
+
+def _signed_jwt(
+    secret: str,
+    *,
+    sub: str = constants.SYSTEM_SERVICE_UID,
+    atr_sys: bool = True,
+    atr_th: str | None = "0" * 64,
+) -> str:
+    now = datetime.datetime.now(tz=datetime.UTC)
+    payload: dict[str, object] = {
+        "sub": sub,
+        "iss": jwtoken._ATR_JWT_ISSUER,
+        "aud": jwtoken._ATR_JWT_AUDIENCE,
+        "iat": now,
+        "nbf": now,
+        "exp": now + datetime.timedelta(minutes=30),
+        "jti": "test-jti",
+    }
+    if atr_sys:
+        payload["atr_sys"] = True
+    if atr_th is not None:
+        payload["atr_th"] = atr_th
+    return jwt.encode(payload, secret, algorithm=jwtoken._ALGORITHM)
+
+
+def _fake_db_session(pat: sql.PersonalAccessToken | None) -> mock.MagicMock:
+    pat_query = mock.MagicMock()
+    pat_query.get = mock.AsyncMock(return_value=pat)
+    fake_data = mock.MagicMock()
+    fake_data.personal_access_token = mock.MagicMock(return_value=pat_query)
+    ctx = mock.AsyncMock()
+    ctx.__aenter__ = mock.AsyncMock(return_value=fake_data)
+    ctx.__aexit__ = mock.AsyncMock(return_value=False)
+    return mock.MagicMock(return_value=ctx)
+
+
+@pytest.mark.asyncio
+async def test_verify_system_token_skips_ldap(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "a" * 64
+    monkeypatch.setattr("atr.jwtoken._signing_key", lambda: secret)
+    monkeypatch.setattr("atr.ldap.is_active", mock.AsyncMock(side_effect=AssertionError("LDAP consulted")))
+    monkeypatch.setattr("atr.db.session", _fake_db_session(_make_pat(is_system=True)))
+
+    claims = await jwtoken.verify(_signed_jwt(secret))
+
+    assert claims["sub"] == constants.SYSTEM_SERVICE_UID
+    assert claims["atr_sys"] is True
+
+
+@pytest.mark.asyncio
+async def test_verify_system_token_rejects_wrong_subject(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "a" * 64
+    monkeypatch.setattr("atr.jwtoken._signing_key", lambda: secret)
+    monkeypatch.setattr("atr.ldap.is_active", mock.AsyncMock(side_effect=AssertionError("LDAP consulted")))
+    monkeypatch.setattr("atr.db.session", _fake_db_session(_make_pat(is_system=True)))
+
+    with pytest.raises(base.ASFQuartException):
+        await jwtoken.verify(_signed_jwt(secret, sub="someuser"))
+
+
+@pytest.mark.asyncio
+async def test_verify_system_token_rejects_non_system_pat(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "a" * 64
+    monkeypatch.setattr("atr.jwtoken._signing_key", lambda: secret)
+    monkeypatch.setattr("atr.ldap.is_active", mock.AsyncMock(side_effect=AssertionError("LDAP consulted")))
+    monkeypatch.setattr("atr.db.session", _fake_db_session(_make_pat(is_system=False)))
+
+    with pytest.raises(base.ASFQuartException):
+        await jwtoken.verify(_signed_jwt(secret))
+
+
+@pytest.mark.asyncio
+async def test_verify_system_claim_without_pat_hash_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "a" * 64
+    monkeypatch.setattr("atr.jwtoken._signing_key", lambda: secret)
+    monkeypatch.setattr("atr.ldap.is_active", mock.AsyncMock(side_effect=AssertionError("LDAP consulted")))
+    with pytest.raises(base.ASFQuartException):
+        await jwtoken.verify(_signed_jwt(secret, atr_th=None))
+
+
+@pytest.mark.asyncio
+async def test_verify_user_token_requires_ldap_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "a" * 64
+    monkeypatch.setattr("atr.jwtoken._signing_key", lambda: secret)
+    is_active = mock.AsyncMock(return_value=False)
+    monkeypatch.setattr("atr.ldap.is_active", is_active)
+
+    with pytest.raises(base.ASFQuartException):
+        await jwtoken.verify(_signed_jwt(secret, sub="someuser", atr_sys=False, atr_th=None))
+    is_active.assert_awaited_once()


### PR DESCRIPTION
Add a new "system" level PAT. Despite the name, they don't get access to everything, but they can be enabled for specific endpoints with a new auth decorator. PATs can be IP limited now (but the option to do so is only shown on the system PAT page which is an admin-only page). The use case for this is the .asf.yaml gitbox process which will need a long-lived credential. This will be 6 months from this PR but we can obviously revisit that in future.