### PR TITLE
Normalize the display of the phase

### DIFF
--- a/atr/render.py
+++ b/atr/render.py
@@ -153,7 +153,9 @@ def html_nav(container: htm.Block, back_url: str, back_anchor: str, phase: Phase
     classes = ".d-flex.justify-content-between.align-items-center"
     block = htm.Block(htm.p, classes=classes)
     block.a(".atr-back-link", href=back_url)[f"← Back to {back_anchor}"]
-    span = htm.Block(htm.span, classes=".atr-phase-nav")
+    container.append(block)
+    card = htm.Block(htm.div, classes=".card-body.text-center.d-flex.flex-column.justify-content-center.float-end")
+    span = htm.Block(htm.div, classes=".atr-phase-themed.mb-2")
 
     def _phase(actual: Phase, expected: Phase) -> None:
         match expected:
@@ -180,7 +182,7 @@ def html_nav(container: htm.Block, back_url: str, back_anchor: str, phase: Phase
                 title = "Vote"
                 phase_number = "two"
             case "FINISH":
-                title = "Finich"
+                title = "Finish"
                 phase_number = "three"
         span.span(f".atr-phase-{phase_number}.atr-phase-label")[title]
 
@@ -190,13 +192,13 @@ def html_nav(container: htm.Block, back_url: str, back_anchor: str, phase: Phase
     span.span(".atr-phase-arrow")["→"]
     _phase(phase, "FINISH")
 
-    block.append(span.collect(separator=" "))
+    card.append(span.collect(separator=" "))
 
-    span = htm.Block(htm.span, classes=".atr-phase-nav")
+    span = htm.Block(htm.div, classes=".atr-phase-themed")
     _phase_title(phase)
 
-    block.append(span.collect(separator=" "))
-    container.append(block)
+    card.append(span.collect(separator=" "))
+    container.append(card.collect(separator=" "))
 
 
 def html_nav_phase(block: htm.Block, project: str, version: str, staging: bool) -> None:

--- a/atr/render.py
+++ b/atr/render.py
@@ -159,21 +159,41 @@ def html_nav(container: htm.Block, back_url: str, back_anchor: str, phase: Phase
         match expected:
             case "COMPOSE":
                 symbol = "①"
+                phase_number = "one"
             case "VOTE":
                 symbol = "②"
+                phase_number = "two"
             case "FINISH":
                 symbol = "③"
+                phase_number = "three"
         if actual == expected:
-            span.strong(f".atr-phase-{actual}.atr-phase-symbol")[symbol]
-            span.span(f".atr-phase-{actual}.atr-phase-label")[actual]
+            span.strong(f".atr-phase-{phase_number}.atr-phase-symbol")[symbol]
         else:
             span.span(".atr-phase-symbol-other")[symbol]
+
+    def _phase_title(actual: Phase) -> None:
+        match actual:
+            case "COMPOSE":
+                title = "Compose"
+                phase_number = "one"
+            case "VOTE":
+                title = "Vote"
+                phase_number = "two"
+            case "FINISH":
+                title = "Finich"
+                phase_number = "three"
+        span.span(f".atr-phase-{phase_number}.atr-phase-label")[title]
 
     _phase(phase, "COMPOSE")
     span.span(".atr-phase-arrow")["→"]
     _phase(phase, "VOTE")
     span.span(".atr-phase-arrow")["→"]
     _phase(phase, "FINISH")
+
+    block.append(span.collect(separator=" "))
+
+    span = htm.Block(htm.span, classes=".atr-phase-nav")
+    _phase_title(phase)
 
     block.append(span.collect(separator=" "))
     container.append(block)

--- a/atr/templates/check-selected.html
+++ b/atr/templates/check-selected.html
@@ -35,21 +35,31 @@
   {% set phase = release.phase.value %}
   <p class="d-flex justify-content-between align-items-center">
     <a href="{{ as_url(get.root.index) }}" class="atr-back-link">← Back to Select a release</a>
-    <span class="atr-phase-nav">
+    <div class="card-body text-center d-flex flex-column justify-content-center float-end">
       {% if phase == "release_candidate_draft" %}
-        <strong class="atr-phase-one atr-phase-symbol">①</strong>
-        <span class="atr-phase-one atr-phase-label">COMPOSE</span>
-        <span class="atr-phase-arrow">→</span>
-        <span class="atr-phase-symbol-other">②</span>
+        <div class="atr-phase-themed mb-2">
+          <strong class="atr-phase-one atr-phase-symbol">①</strong>
+          <span class="atr-phase-arrow">→</span>
+          <span class="atr-phase-symbol-other">②</span>
+          <span class="atr-phase-arrow">→</span>
+          <span class="atr-phase-symbol-other">③</span>
+        </div>
+        <div class="atr-phase-themed">
+          <span class="atr-phase-one atr-phase-label">Compose</span>
+        </div>
       {% else %}
-        <span class="atr-phase-symbol-other">①</span>
-        <span class="atr-phase-arrow">→</span>
-        <strong class="atr-phase-two atr-phase-symbol">②</strong>
-        <span class="atr-phase-two atr-phase-label">VOTE</span>
+        <div class="atr-phase-themed mb-2">
+          <span class="atr-phase-symbol-other">①</span>
+          <span class="atr-phase-arrow">→</span>
+          <strong class="atr-phase-two atr-phase-symbol">②</strong>
+          <span class="atr-phase-arrow">→</span>
+          <span class="atr-phase-symbol-other">③</span>
+        </div>
+        <div class="atr-phase-themed">
+          <span class="atr-phase-two atr-phase-label">Vote</span>
+        </div>
       {% endif %}
-      <span class="atr-phase-arrow">→</span>
-      <span class="atr-phase-symbol-other">③</span>
-    </span>
+    </div>
   </p>
 
   {% if phase == "release_candidate_draft" %}

--- a/atr/templates/download-all.html
+++ b/atr/templates/download-all.html
@@ -9,30 +9,42 @@
   <p class="d-flex justify-content-between align-items-center">
     <a href="{{ back_url }}" class="atr-back-link">← Back to {{ phase|replace('_', ' ') |title }}</a>
     {% if phase != "release" %}
-      <span class="atr-phase-nav">
+      <div class="card-body text-center d-flex flex-column justify-content-center float-end">
         {% if phase == "release_candidate_draft" %}
-          <strong class="atr-phase-one atr-phase-symbol">①</strong>
-          <span class="atr-phase-one atr-phase-label">COMPOSE</span>
-          <span class="atr-phase-arrow">→</span>
-          <span class="atr-phase-symbol-other">②</span>
-          <span class="atr-phase-arrow">→</span>
-          <span class="atr-phase-symbol-other">③</span>
+          <div class="atr-phase-themed mb-2">
+            <strong class="atr-phase-one atr-phase-symbol">①</strong>
+            <span class="atr-phase-arrow">→</span>
+            <span class="atr-phase-symbol-other">②</span>
+            <span class="atr-phase-arrow">→</span>
+            <span class="atr-phase-symbol-other">③</span>
+          </div>
+          <div class="atr-phase-themed">
+            <span class="atr-phase-one atr-phase-label">Compose</span>
+          </div>
         {% elif phase == "release_candidate" %}
-          <span class="atr-phase-symbol-other">①</span>
-          <span class="atr-phase-arrow">→</span>
-          <strong class="atr-phase-two atr-phase-symbol">②</strong>
-          <span class="atr-phase-two atr-phase-label">VOTE</span>
-          <span class="atr-phase-arrow">→</span>
-          <span class="atr-phase-symbol-other">③</span>
+          <div class="atr-phase-themed mb-2">
+            <span class="atr-phase-symbol-other">①</span>
+            <span class="atr-phase-arrow">→</span>
+            <strong class="atr-phase-two atr-phase-symbol">②</strong>
+            <span class="atr-phase-arrow">→</span>
+            <span class="atr-phase-symbol-other">③</span>
+          </div>
+          <div class="atr-phase-themed">
+            <span class="atr-phase-two atr-phase-label">Vote</span>
+          </div>
         {% elif phase == "release_preview" %}
-          <span class="atr-phase-symbol-other">①</span>
-          <span class="atr-phase-arrow">→</span>
-          <span class="atr-phase-symbol-other">②</span>
-          <span class="atr-phase-arrow">→</span>
-          <strong class="atr-phase-three atr-phase-symbol">③</strong>
-          <span class="atr-phase-three atr-phase-label">FINISH</span>
+          <div class="atr-phase-themed mb-2">
+            <span class="atr-phase-symbol-other">①</span>
+            <span class="atr-phase-arrow">→</span>
+            <strong class="atr-phase-symbol-other">②</span>
+            <span class="atr-phase-arrow">→</span>
+            <strong class="atr-phase-three atr-phase-symbol">③</strong>
+          </div>
+          <div class="atr-phase-themed">
+            <span class="atr-phase-three atr-phase-label">Finish</span>
+          </div>
         {% endif %}
-      </span>
+      </div>
     {% endif %}
   </p>
 

--- a/atr/templates/report-selected-path.html
+++ b/atr/templates/report-selected-path.html
@@ -27,21 +27,31 @@
       <a href="{{ as_url(get.vote.selected, project_key=release.project.key, version_key=release.version) }}"
          class="atr-back-link">← Back to Vote on {{ release.project.short_display_name }} {{ release.version }}</a>
     {% endif %}
-    <span class="atr-phase-nav">
+    <div class="card-body text-center d-flex flex-column justify-content-center float-end">
       {% if phase == "release_candidate_draft" %}
-        <strong class="atr-phase-one atr-phase-symbol">①</strong>
-        <span class="atr-phase-one atr-phase-label">COMPOSE</span>
-        <span class="atr-phase-arrow">→</span>
-        <span class="atr-phase-symbol-other">②</span>
+        <div class="atr-phase-themed mb-2">
+          <strong class="atr-phase-one atr-phase-symbol">①</strong>
+          <span class="atr-phase-arrow">→</span>
+          <span class="atr-phase-symbol-other">②</span>
+          <span class="atr-phase-arrow">→</span>
+          <span class="atr-phase-symbol-other">③</span>
+        </div>
+        <div class="atr-phase-themed">
+          <span class="atr-phase-one atr-phase-label">Compose</span>
+        </div>
       {% else %}
-        <span class="atr-phase-symbol-other">①</span>
-        <span class="atr-phase-arrow">→</span>
-        <strong class="atr-phase-two atr-phase-symbol">②</strong>
-        <span class="atr-phase-two atr-phase-label">VOTE</span>
+        <div class="atr-phase-themed mb-2">
+          <span class="atr-phase-symbol-other">①</span>
+          <span class="atr-phase-arrow">→</span>
+          <strong class="atr-phase-two atr-phase-symbol">②</strong>
+          <span class="atr-phase-arrow">→</span>
+          <span class="atr-phase-symbol-other">③</span>
+        </div>
+        <div class="atr-phase-themed">
+          <span class="atr-phase-two atr-phase-label">Vote</span>
+        </div>
       {% endif %}
-      <span class="atr-phase-arrow">→</span>
-      <span class="atr-phase-symbol-other">③</span>
-    </span>
+    </div>
   </p>
 
   <h1>


### PR DESCRIPTION
Closes #1202 

This PR will make two changes to make the phase status display follow the same layout as it does on pick a release candidate cards.

1. The html templates with this display.
2. The `html_nav` function in `render.py`

Part 1 is present. Part 2 is already buggy, but will take some time.