### PR TITLE
fix inactivity message: candidate draft, not release nor project

### DIFF
--- a/atr/shared/activity.py
+++ b/atr/shared/activity.py
@@ -26,7 +26,7 @@ def inactivity_form_intro(release: sql.Release, action: str = "deleted") -> htm.
     days = max(0, (datetime.datetime.now(datetime.UTC) - release.activity_at).days)
     return htm.div[
         htm.div(".mb-2")[
-            f"This release has been inactive for {util.plural(days, 'day')}. "
-            f"After 90 days of inactivity this project will be {action}."
+            f"This candidate draft has been inactive for {util.plural(days, 'day')}. "
+            f"After 90 days of inactivity, this candidate draft will be {action}."
         ],
     ]


### PR DESCRIPTION
## Pull request summary 

small wording fix:
actual: "This release has been inactive for 0 days. After 90 days of inactivity this project will be deleted."
target: "This candidate draft has been inactive for 0 days. After 90 days of inactivity, this candidate draft will be deleted."

**Description:**

wording consistency