### PR TITLE
Update components

### DIFF
--- a/atr/docs/index.md
+++ b/atr/docs/index.md
@@ -8,7 +8,7 @@ NOTE: This documentation is a work in progress.
 
 * `1.` [Introduction to ATR](introduction-to-atr)
 * `2.` [User guide](user-guide)
-  * `2.1.` [Components](components)
+  * `2.1.` [Terminology](terminology)
   * `2.2.` [Signing artifacts](signing-artifacts)
   * `2.3.` [Checks](checks)
   * `2.4.` [License checks](license-checks)

--- a/atr/docs/signing-artifacts.md
+++ b/atr/docs/signing-artifacts.md
@@ -2,7 +2,7 @@
 
 **Up**: `2.` [User guide](user-guide)
 
-**Prev**: `2.1.` [Components](components)
+**Prev**: `2.1.` [Terminology](terminology)
 
 **Next**: `2.3.` [Checks](checks)
 

--- a/atr/docs/terminology.md
+++ b/atr/docs/terminology.md
@@ -1,4 +1,4 @@
-# 2.1. Components
+# 2.1. Terminology
 
 **Up**: `2.` [User guide](user-guide)
 

--- a/atr/docs/terminology.md
+++ b/atr/docs/terminology.md
@@ -17,34 +17,50 @@
 
 ## Introduction
 
-ATR knows about several kinds of components that correspond to organizational resources at the ASF, but some of the components mean a slightly different thing in ATR or are customized in some way. This page documents the major things to know about, and what's special about them.
+ATR knows about several kinds of components that correspond to organizational resources at the ASF, but for some of these components we make refinements. This page documents the major terminology as used in ATR.
 
-The way that ATR models components has the effect of incorporating extremes such as Airflow, Maven, Commons, Sling, etc. We studied the release patterns before designing this system, and we plan eventually to catalog all current project releases in a new system adjacent to or included within ATR.
+The way that ATR models components has allowed us to incorporate some extreme release models of certain PMCs like Airflow, Maven, Commons, Sling, etc. We studied the release patterns before designing this system.
 
 ## Committee
 
-A **committee** in ATR is a PMC (Project Management Committee), or a PPMC (Podling Project Management Committee). The concept of a committee is important in ATR because both its members and all release managers have elevated permissions compared to non-member and non-release-manager committers.
+A ***Committee*** in ATR is a PMC (Project Management Committee), or a PPMC (Podling Project Management Committee). The concept of a committee is important in ATR because both its members and all release managers have elevated permissions compared to non-member and non-release-manager committers.
 
-Committees in ATR have one or more projects.
+* Committees in ATR have one or more ***Projects***.
+* The ***Roster*** shows the committers and PMC Members of the committee and allows for designation of committers as Release Managers
+* ***Permissions*** shows if the Committee is allowed to build release artifacts in ***CI***.
+* Each committee has a list of ***Signing Keys*** which may be used to sign artifacts.
 
 ## Project
 
-A **project** in ATR produces software or bundle of software that a committee votes on. This means that if your committee bundles several kinds of software together for a vote, that still counts as only one project in ATR. You must pick a version number for the "bundled" software in such a case, but of course your constituent software still has its own individual version numbers and we plan for ATR to be made aware of those too.
+A ***Project*** in ATR produces software or bundle of software that a committee votes on. This means that if your committee bundles several kinds of software together for a vote, that still counts as only one project in ATR. You must pick a version number for the "bundled" software in such a case, but of course your constituent software still has its own individual version numbers and we plan for ATR to be made aware of those too.
 
-Projects in ATR have one or more releases.
+* Projects in ATR have one or more ***Releases***.
+* Each project has ***Metadata*** which includes descriptions and various urls. A download page url is required.
+* There are ***Security*** settings for each project.
+* The project has a ***Lifecycle*** which can follow several version schemas and allow multiple active branches.
+* See [***Trusted Publishing***](trusted-publishing).
+* There are project ***Compose***, ***Vote***, and ***Finish*** policies.
+* ***Common Lifecycle Events*** are generated for project releases.
 
 ## Release
 
-A **release** in ATR is a specific version of software or bundle of software produced by a project. As mentioned in the project section above, bundled software must have an overall version number that may be different from the version numbers of the constituent software in the bundle. Also, we allow the release of more than one release concurrently, and we allow the release of prior versions (e.g. security patch level versions) after later versions.
+A ***Release*** in ATR is a specific version of software or bundle of software produced by a project. As mentioned in the project section above, bundled software must have an overall version number that may be different from the version numbers of the constituent software in the bundle. Also, we allow the release of more than one release concurrently, and we allow the release of prior versions (e.g. security patch level versions) after later versions.
 
-Releases in ATR have one or more revisions.
+* Releases in ATR have one or more ***Versions***.
+* While a Release Candidate there may be multiple ***Revisions*** of the release.
+* Once ***Released*** a version may be ***Archived***.
 
 ## Revision
 
-A **revision** is a snapshot of a release during the process of it being prepared by the release manager or release managers. There are two preparation phases: before and after voting. The phase before voting is called the _compose_ phase and the phase after voting is called the _finish_ phase. In these phases it is possible, subject to certain constraints (many more after voting than before), to add files, move files, edit files, and delete files, and each such modification produces a new revision. This helps release managers to audit each other's activity, restore more easily after mistakes, and pin to a specific set for voting and final release without incurring races.
+A ***Revision*** is a snapshot of a release during the process of it being prepared by the release manager or release managers. Revisions are only accessible before voting in the ***Compose*** phase. In this phase it is possible, subject to certain constraints, to add files, move files, edit files, and delete files, and each such modification produces a new revision. This helps release managers to audit each other's activity, restore more easily after mistakes, and pin to a specific set for voting and final release without incurring races.
 
 Revisions in ATR have one or more artifacts.
 
 ## Artifact
 
-An **artifact** is a file that has been uploaded by a release manager to a revision, and will constitute part of the release to be voted on, distributed, and officially announced. ATR will automatically check artifacts for adherence to as many ASF policies as we can automate checking for. It provides them for download during all phases before final release, and then will publish them through official channels during final release. At the moment, in alpha phase (as of January 2026), we do not yet do publication, and this must be done manually by a release manager.
+An ***Artifact*** is a file that has been uploaded by a release manager to a revision, and will constitute part of the release to be voted on, distributed, and officially announced. ATR will automatically check artifacts for adherence to as many ASF policies as we can automate checking for. It provides them for download during all phases before final release, and then will publish them through official channels during final release.
+
+* Each release has one or more ***Artifacts*** one of which must be a ***Source*** artifact.
+* Every artifact must have a detached ***Signature*** and ***Checksum***.
+* ***SBOMs*** may be offered as artifacts or generated as additional artifact metadata.
+* Various [***Checks***](checks) are run on the artifacts.

--- a/atr/docs/user-guide.md
+++ b/atr/docs/user-guide.md
@@ -61,7 +61,7 @@ The ASF releases open source software. The ATR platform helps PMCs release their
    * ***Vote***. In this phase the PMC votes on the release and approves (or not). Votes may be canceled. Once the vote passes it is ready to publish.
    * ***Finish***. In this phase the Release Artifacts are committed to `svn:dist:release` and announcement is deferred until the artifacts have made it
      onto the download servers. The announcement is sent and the artifacts published to the Release Catalog.
-2. ***Active***. Releases that are active are cataloged and available via both a standard catalog api and at the proper urls using the CDN and download servers.
+2. ***Released***. Releases that are released are active and cataloged and available via both a standard catalog api and at the proper urls using the CDN and download servers.
    Releases that use the current legacy methods skipping the ATR are also cataloged,
 3. ***Archived***. All cataloged releases may be archived using the ATR platform or by direct removal from `svn:dist:release`.
 

--- a/atr/docs/user-guide.md
+++ b/atr/docs/user-guide.md
@@ -8,7 +8,7 @@
 
 **Pages**:
 
-* `2.1.` [Terminology](Terminology)
+* `2.1.` [Terminology](terminology)
 * `2.2.` [Signing artifacts](signing-artifacts)
 * `2.3.` [Checks](checks)
 * `2.4.` [License checks](license-checks)
@@ -19,7 +19,57 @@
 **Sections**:
 
 * [Introduction](#introduction)
+* [Committee](#committee)
+* [Project](#project)
+* [Releases](#releases)
+* [Catalog](#catalog)
+* [Tutorial](#tutorial)
 
 ## Introduction
 
-This is a work in progress. Meanwhile, you can read the [ATR tutorial](/tutorial).
+The Apache Trusted Releases (***ATR***) provides a standard and easy way for a Project Management Committee (***PMC***) or incubating project (***PPMC***)
+to manage their releases in order to easily follow the Apache Way of governance. Most ASF documentation and systems use the following
+interchangable terms for PMCs: "Projects", Top Level Project (TLP), and "Podlings". For the ATR we felt it was important to make a distinction
+between the people involved in the PMC and the software produced. The platform provides a way for a committee to manage their project's software
+releases.
+
+## Committee
+
+Within the ATR platform when we describe PMCs as ***Committees***. We refer to the committee's ***Roster*** as having ***PMC Members*** and ***Committers***. Each of
+these individuals may have assigned ***GPG public keys*** to the PMC. PMC members have ***binding release votes*** and can be ***Release Managers***.
+Designated committers may be explicitly allowed to be Release Mangers.
+
+Committee status is determined outside of the ATR system by either the Board of Directors for PMCs or by the Incubator PMC for PPMCs.
+
+## Project
+
+Within the ATR platform we make a distinction between the committee and its software project(s). While most PMCs have a single project some have
+multiple projects and in some cases a large number. ***Projects*** typically each have different repositories and release cycles within a PMC.
+Often these are called sub-projects. Some projects have active releases on multiple versions. ATR can handle all of this structural diversity.
+When using ATR it will be important for PMCs to acknowledge their *true number of projects*.
+
+Projects are initially defined based on ***DOAP files*** and observed release activity. Once a PMC uses the ATR then projects are defined both within
+the platform and via `.asf.yaml`. The tooling team will work with PMCs to properly update their projects.
+
+## Releases
+
+The ASF releases open source software. The ATR platform helps PMCs release their project's artifacts through several stages:
+
+1. ***Candidate***. Guiding a ***Release Candidate*** through the phases of ASF Governance to make a Release is the primary purpose of the ATR platform.
+   * ***Compose***. In this phase ***Release Artifacts*** are assembled and checked for compliance.
+     The Release Manager can iterate on the artifacts until the Candidate is ready.
+   * ***Vote***. In this phase the PMC votes on the release and approves (or not). Votes may be canceled. Once the vote passes it is ready to publish.
+   * ***Finish***. In this phase the Release Artifacts are committed to `svn:dist:release` and announcement is deferred until the artifacts have made it
+     onto the download servers. The announcement is sent and the artifacts published to the Release Catalog.
+2. ***Active***. Releases that are active are cataloged and available via both a standard catalog api and at the proper urls using the CDN and download servers.
+   Releases that use the current legacy methods skipping the ATR are also cataloged,
+3. ***Archived***. All cataloged releases may be archived using the ATR platform or by direct removal from `svn:dist:release`.
+
+## Catalog
+
+ATR includes a ***Catalog*** of all active and archived release artifacts with a set url pattern that includes the ***Project key***, ***Release version***, and
+***Artifact name***. Using this pattern on an endpoint using curl the ASF's preferred urls for a release's artifacts and metadata are obtained.
+
+## Tutorial
+
+We offer an [ATR tutorial](/tutorial).

--- a/atr/docs/user-guide.md
+++ b/atr/docs/user-guide.md
@@ -8,7 +8,7 @@
 
 **Pages**:
 
-* `2.1.` [Components](components)
+* `2.1.` [Terminology](Terminology)
 * `2.2.` [Signing artifacts](signing-artifacts)
 * `2.3.` [Checks](checks)
 * `2.4.` [License checks](license-checks)


### PR DESCRIPTION
Closes #1339 

Updates the users-guide, renames the component page to terminology, and expands on terminology,