### PR TITLE
Remove links to ATR's own downloads area

### DIFF
--- a/atr/construct.py
+++ b/atr/construct.py
@@ -199,8 +199,6 @@ async def announce_release_default(project_key: safe.ProjectKey) -> str:
 async def announce_release_subject_and_body(
     subject: str, body: str, options: AnnounceReleaseOptions
 ) -> tuple[str, str]:
-    host = config.get().APP_HOST
-
     async with db.session() as data:
         release = await data.release(
             project_key=str(options.project_key),
@@ -219,10 +217,8 @@ async def announce_release_subject_and_body(
 
     project = release.project
     project_display_name = project.short_display_name if project else str(options.project_key)
-    download_url = util.public_download_url(committee, None, util.DownloadFile.METADATA, host=host)
-    if options.download_path_suffix is not None:
-        download_url += f"/{options.download_path_suffix!s}"
-    download_url += "/"
+    download_relpath = paths.committee_dist_relpath(committee, options.download_path_suffix)
+    download_url = f"{paths.downloads_url(download_relpath)}/"
 
     values: _AnnounceValues = {
         "BUG_DATABASE": project.bug_database or "",
@@ -242,7 +238,6 @@ async def announce_release_subject_and_body(
         "YOUR_ASF_ID": options.asfuid,
         "YOUR_FULL_NAME": options.fullname,
     }
-    values["DOWNLOAD_URL"] = util.released_dist_url(values["DOWNLOAD_URL"])
     subject = _substitute(subject, values, "announce_subject")
     body = _substitute(body, values, "announce")
     return subject, body

--- a/atr/get/announce.py
+++ b/atr/get/announce.py
@@ -29,6 +29,7 @@ import atr.get.projects as projects
 import atr.htm as htm
 import atr.models.safe as safe
 import atr.models.sql as sql
+import atr.paths as paths
 import atr.post as post
 import atr.render as render
 import atr.shared as shared
@@ -93,7 +94,7 @@ async def selected(
         default_subject_template, default_body_template, options
     )
 
-    description_download_prefix = util.public_download_url(committee, None, util.DownloadFile.METADATA)
+    description_download_prefix = paths.downloads_url(paths.committee_dist_relpath(committee))
     preview_url = util.as_url(
         post.announce.preview,
         project_key=release.project.key,

--- a/atr/paths.py
+++ b/atr/paths.py
@@ -48,7 +48,8 @@ def committee_dist_relpath(
     # The committee's path relative to the downloads root, ie the shared prefix that
     # the download hosts and the distribution SVN area both hang a release off.
     # Optionally extended with the per-release download suffix and a file name.
-    relpath = safe.RelPath.from_path(committee_downloads_dir(committee).path.relative_to(get_downloads_dir().path))
+    prefix = "incubator/" if committee.is_podling else ""
+    relpath = safe.RelPath(f"{prefix}{committee.key}")
     if suffix is not None:
         relpath = relpath.append(suffix.as_path())
     if filename is not None:
@@ -63,17 +64,8 @@ def committee_downloads_dir(committee: sql.Committee) -> safe.StatePath:
     return downloads_dir / committee.key
 
 
-def committee_downloads_url(host: str, committee: sql.Committee) -> str:
-    # This is a slight extension of the intended paths concept
-    # But URLs contain paths, so atr.paths does not have to be limited to filesystem paths
-    if committee.is_podling:
-        return f"https://{host}/downloads/incubator/{committee.key}"
-    return f"https://{host}/downloads/{committee.key}"
-
-
 def committee_keys_url(committee: sql.Committee) -> str:
-    prefix = "incubator/" if committee.is_podling else ""
-    return downloads_url(safe.RelPath(f"{prefix}{committee.key}/KEYS"))
+    return downloads_url(committee_dist_relpath(committee, filename="KEYS"))
 
 
 def downloads_url(relpath: safe.RelPath) -> str:

--- a/atr/shared/catalog.py
+++ b/atr/shared/catalog.py
@@ -36,14 +36,6 @@ class CatalogProject:
     grouped: bool
 
 
-def cle_project_url(atr_host: str, project_key: str) -> str:
-    return f"https://{atr_host}/api/cle/project/{project_key}"
-
-
-def cle_release_url(atr_host: str, project_key: str, version: str) -> str:
-    return f"https://{atr_host}/api/cle/release/{project_key}/{version}"
-
-
 def assemble(
     version_method: sql.VersionMethod,
     artifacts: Sequence[sql.Artifact],
@@ -65,6 +57,14 @@ def assemble(
     return CatalogProject(versions=versions, cycles=cycles, grouped=grouped)
 
 
+def cle_project_url(atr_host: str, project_key: str) -> str:
+    return f"https://{atr_host}/api/cle/project/{project_key}"
+
+
+def cle_release_url(atr_host: str, project_key: str, version: str) -> str:
+    return f"https://{atr_host}/api/cle/release/{project_key}/{version}"
+
+
 def _artifact(row: sql.Artifact, downloadable: bool, archived: bool) -> models.api.CatalogArtifact:
     artifact_url: str | None = None
     signature_url: str | None = None
@@ -79,7 +79,7 @@ def _artifact(row: sql.Artifact, downloadable: bool, archived: bool) -> models.a
 
         def _dist_url(rel_path: str, kind: util.DownloadFile) -> str:
             relpath = directory.append(rel_path) if (directory is not None) else safe.RelPath(rel_path)
-            return util.released_dist_url(util.download_url_for_path(relpath, kind, archived=archived))
+            return util.download_url_for_path(relpath, kind, archived=archived)
 
         artifact_url = _dist_url(row.artifact_path, util.DownloadFile.ARTIFACT)
         if row.signature_path:
@@ -106,9 +106,9 @@ def _artifact(row: sql.Artifact, downloadable: bool, archived: bool) -> models.a
     )
 
 
-def _grouped_layout(version_method: sql.VersionMethod) -> bool:
-    # Simple projects have only the default cycle, so they skip cycle grouping.
-    return version_method in _GROUPED_METHODS
+def _cycle_sort_key(cycle: sql.ProjectCycle) -> datetime.datetime:
+    # Most recently active cycle first.
+    return cycle.latest or datetime.datetime.min.replace(tzinfo=datetime.UTC)
 
 
 def _cycles(
@@ -130,9 +130,9 @@ def _cycles(
     return catalog
 
 
-def _cycle_sort_key(cycle: sql.ProjectCycle) -> datetime.datetime:
-    # Most recently active cycle first.
-    return cycle.latest or datetime.datetime.min.replace(tzinfo=datetime.UTC)
+def _grouped_layout(version_method: sql.VersionMethod) -> bool:
+    # Simple projects have only the default cycle, so they skip cycle grouping.
+    return version_method in _GROUPED_METHODS
 
 
 def _lifecycle_badge(cycle: sql.ProjectCycle, now: datetime.datetime) -> str:

--- a/atr/storage/writers/announce.py
+++ b/atr/storage/writers/announce.py
@@ -238,7 +238,7 @@ class ReleaseManager(CommitteeParticipant):
                     )
             try:
                 target = util.svn_publish_target()
-                public_url = util.public_download_url(
+                public_url = util.publication_check_url(
                     committee, effective_download_path_suffix, util.DownloadFile.METADATA
                 )
             except ValueError as exc:

--- a/atr/util.py
+++ b/atr/util.py
@@ -652,26 +652,14 @@ def download_page_url_error(url: str) -> str | None:
     return "Must not use a literal IP address"
 
 
-def download_url_for_path(
-    relpath: safe.RelPath, kind: DownloadFile, host: str | None = None, archived: bool = False
-) -> str:
-    # Where a file at a known dist-relative path is fetched from, by lifecycle (archived vs beta vs
-    # released) and role (artifact vs metadata). The catalogue stores each artifact's exact path, so
-    # nothing has to be reconstructed from a committee here
+def download_url_for_path(relpath: safe.RelPath, kind: DownloadFile, archived: bool = False) -> str:
+    # Where a published file at a known dist-relative path is fetched from. Release artifacts use
+    # the mirror network; verification metadata uses the canonical host; archived files use the archive.
     if archived:
-        # archive.apache.org keeps every release ever published, on every host
         return paths.archive_download_url(relpath)
-    if not config.get().SVN_PUBLISH_URL:
-        # No SVN publishing configured (dev), so ATR serves the downloads itself
-        return f"https://{host or config.get().APP_HOST}/downloads/{relpath}"
-    match svn_publish_target():
-        case SvnPublishTarget.ATR:
-            # Beta: files are still in ATR's area of the distribution SVN, not yet mirrored
-            return f"{config.get().SVN_DIST_PUBLIC_URL.rstrip('/')}/{relpath}"
-        case SvnPublishTarget.RELEASE:
-            if kind is DownloadFile.ARTIFACT:
-                return paths.closer_download_url(relpath)
-            return paths.downloads_url(relpath)
+    if kind is DownloadFile.ARTIFACT:
+        return paths.closer_download_url(relpath)
+    return paths.downloads_url(relpath)
 
 
 def email_from_uid(uid: str) -> str | None:
@@ -1215,26 +1203,17 @@ def proc_memory_kb(pid: int) -> tuple[int | None, int | None]:
     return rss, hwm
 
 
-def public_download_url(
+def publication_check_url(
     committee: sql.Committee,
     suffix: safe.RelPath | None,
     kind: DownloadFile,
     filename: str | None = None,
-    host: str | None = None,
 ) -> str:
-    # Where a live release file is fetched from, built from its committee (which knows is_podling)
-    # plus the release suffix and file name. Historical catalogue artifacts resolve from their
-    # stored path via download_url_for_path instead, and never come through here
-    if not config.get().SVN_PUBLISH_URL:
-        # No SVN publishing (dev): ATR serves downloads itself, built config-light without the
-        # storage-dir the dist relpath would otherwise need
-        base = paths.committee_downloads_url(host or config.get().APP_HOST, committee)
-        if suffix is not None:
-            base = f"{base}/{suffix}"
-        if filename is not None:
-            base = f"{base}/{filename}"
-        return base
-    return download_url_for_path(paths.committee_dist_relpath(committee, suffix, filename), kind, host)
+    # Where a file published to the configured SVN target can be checked before announcement.
+    relpath = paths.committee_dist_relpath(committee, suffix, filename)
+    if svn_publish_target() is SvnPublishTarget.ATR:
+        return f"{config.get().SVN_DIST_PUBLIC_URL.rstrip('/')}/{relpath}"
+    return download_url_for_path(relpath, kind)
 
 
 async def read_file_for_viewer(full_path: safe.StatePath, max_size: int) -> tuple[str | None, bool, bool, str | None]:
@@ -1278,15 +1257,6 @@ async def read_file_for_viewer(full_path: safe.StatePath, max_size: int) -> tupl
         error_message = f"An error occurred reading the file: {e!s}"
 
     return content, is_text, is_truncated, error_message
-
-
-def released_dist_url(url: str) -> str:
-    # Temporary fix for alpha: a released artifact's files are assumed to have been moved out of
-    # ATR's beta dist area into the release area, so point downloads there rather than at /dist/atr
-    # TODO: Remove this once ATR performs the SVN move to the release area itself
-    if "dist/atr" in url:
-        return url.replace("dist/atr", "dist/release")
-    return url
 
 
 async def session_cache_read() -> dict[str, dict]:

--- a/tests/e2e/announce/test_get.py
+++ b/tests/e2e/announce/test_get.py
@@ -23,7 +23,7 @@ from playwright.sync_api import Page, expect
 
 def test_body_contains_public_downloads_url_by_default(page_announce: Page) -> None:
     body = page_announce.locator("#body")
-    expect(body).to_have_value(re.compile(r"https://[^/\s]+(?::\d+)?/downloads/test/"))
+    expect(body).to_have_value(re.compile(r"https://downloads\.apache\.org/test/"))
 
 
 def test_body_stops_syncing_after_customization(page_announce: Page) -> None:
@@ -35,18 +35,19 @@ def test_body_stops_syncing_after_customization(page_announce: Page) -> None:
     expect(body).to_have_value("Custom body")
 
     page_announce.locator("#discard-announce-body-changes").click()
-    expect(body).to_have_value(re.compile(r"https://[^/\s]+(?::\d+)?/downloads/test/apple/banana/"))
+    expect(body).to_have_value(re.compile(r"https://downloads\.apache\.org/test/apple/banana/"))
 
 
 def test_body_updates_download_url_while_pristine(page_announce: Page) -> None:
     body = page_announce.locator("#body")
     page_announce.locator("#download_path_suffix").fill("apple/banana")
-    expect(body).to_have_value(re.compile(r"https://[^/\s]+(?::\d+)?/downloads/test/apple/banana/"))
+    expect(body).to_have_value(re.compile(r"https://downloads\.apache\.org/test/apple/banana/"))
 
 
 def test_path_adds_leading_slash(page_announce: Page) -> None:
     """Paths without a leading '/' should have one added."""
     help_text = helpers.fill_path_suffix(page_announce, "apple/banana")
+    expect(help_text).to_contain_text("https://downloads.apache.org/test")
     expect(help_text).to_contain_text("/apple/banana/")
 
 

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -17,6 +17,7 @@
 
 import datetime
 
+import atr.constants as constants
 import atr.models.api as api
 import atr.models.sql as sql
 import atr.shared.catalog as catalog
@@ -35,6 +36,19 @@ class _CatalogVersionStub:
             cycle=cycle.cycle if cycle is not None else None,
             artifacts=[],
         )
+
+
+def test_archived_status_holds_without_an_archive_date() -> None:
+    # A release known to be archived but with no date (a catalogued historical release) carries
+    # is_archived alone; it still reads as archived, and stays downloadable off archive.apache.org
+    project = _project()
+    undated = _release(project, "3.11.0", cycle_key="cassandra-default", released=_NOW, is_archived=True)
+    artifacts = [_artifact(project, "3.11.0", "a-3.11.0.tar.gz", release=undated)]
+
+    versions = {str(v.version): v for v in catalog._versions(artifacts, {})}
+
+    assert versions["3.11.0"].status == "archived"
+    assert versions["3.11.0"].artifacts[0].downloadable is True
 
 
 def test_cle_url_is_omitted_for_versions_without_a_backing_release() -> None:
@@ -88,6 +102,18 @@ def test_lifecycle_badge_prefers_lts_then_eol_then_active() -> None:
     assert catalog._lifecycle_badge(_cycle("5.0"), _NOW) == "Active"
 
 
+def test_paired_sbom_shown_on_catalog_artifact() -> None:
+    project = _project()
+    released = _release(project, "5.0.2", cycle_key="cassandra-default", released=_NOW)
+    artifacts = [
+        _artifact(project, "5.0.2", "a-5.0.2.tar.gz", release=released, sbom_path="a-5.0.2.tar.gz.cdx.json"),
+    ]
+
+    versions = {str(v.version): v for v in catalog._versions(artifacts, {})}
+
+    assert versions["5.0.2"].artifacts[0].sbom_path == "a-5.0.2.tar.gz.cdx.json"
+
+
 def test_released_and_archived_versions_are_downloadable() -> None:
     project = _project()
     released = _release(project, "5.0.2", cycle_key="cassandra-default", released=_NOW)
@@ -105,16 +131,26 @@ def test_released_and_archived_versions_are_downloadable() -> None:
     assert versions["4.1.7"].svn_revision == 28114
 
 
-def test_paired_sbom_shown_on_catalog_artifact() -> None:
+def test_released_catalog_urls_use_mirrors_and_canonical_metadata() -> None:
     project = _project()
     released = _release(project, "5.0.2", cycle_key="cassandra-default", released=_NOW)
-    artifacts = [
-        _artifact(project, "5.0.2", "a-5.0.2.tar.gz", release=released, sbom_path="a-5.0.2.tar.gz.cdx.json"),
-    ]
+    artifact = _artifact(
+        project,
+        "5.0.2",
+        "a-5.0.2.tar.gz",
+        release=released,
+        signature_path="a-5.0.2.tar.gz.asc",
+        checksum_path="a-5.0.2.tar.gz.sha512",
+        sbom_path="a-5.0.2.tar.gz.cdx.json",
+    )
 
-    versions = {str(v.version): v for v in catalog._versions(artifacts, {})}
+    result = catalog._artifact(artifact, downloadable=True, archived=False)
 
-    assert versions["5.0.2"].artifacts[0].sbom_path == "a-5.0.2.tar.gz.cdx.json"
+    base = "cassandra/5.0.2/a-5.0.2.tar.gz"
+    assert result.artifact_url == f"{constants.CLOSER_LUA_URL}/{base}?action=download"
+    assert result.signature_url == f"{constants.DOWNLOADS_APACHE_URL}/{base}.asc"
+    assert result.checksum_url == f"{constants.DOWNLOADS_APACHE_URL}/{base}.sha512"
+    assert result.sbom_url == f"{constants.DOWNLOADS_APACHE_URL}/{base}.cdx.json"
 
 
 def test_simple_projects_use_the_flat_layout() -> None:
@@ -134,19 +170,6 @@ def test_status_reflects_release_and_archive_state() -> None:
 
     assert versions["5.0.2"].status == "released"
     assert versions["4.1.7"].status == "archived"
-
-
-def test_archived_status_holds_without_an_archive_date() -> None:
-    # A release known to be archived but with no date (a catalogued historical release) carries
-    # is_archived alone; it still reads as archived, and stays downloadable off archive.apache.org
-    project = _project()
-    undated = _release(project, "3.11.0", cycle_key="cassandra-default", released=_NOW, is_archived=True)
-    artifacts = [_artifact(project, "3.11.0", "a-3.11.0.tar.gz", release=undated)]
-
-    versions = {str(v.version): v for v in catalog._versions(artifacts, {})}
-
-    assert versions["3.11.0"].status == "archived"
-    assert versions["3.11.0"].artifacts[0].downloadable is True
 
 
 def test_svn_revision_alone_does_not_make_a_version_managed() -> None:
@@ -215,6 +238,8 @@ def _artifact(
     *,
     release: sql.Release | None = None,
     svn_revision: int | None = None,
+    signature_path: str | None = None,
+    checksum_path: str | None = None,
     sbom_path: str | None = None,
     managed: bool = False,
     dated: datetime.datetime | None = None,
@@ -226,6 +251,8 @@ def _artifact(
         release_key=(release.key if release is not None else None),
         release=release,
         svn_revision=svn_revision,
+        signature_path=signature_path,
+        checksum_path=checksum_path,
         sbom_path=sbom_path,
         download_path_suffix=f"{project.key}/{version}",
         managed=managed,

--- a/tests/unit/test_construct_announce.py
+++ b/tests/unit/test_construct_announce.py
@@ -66,11 +66,6 @@ async def test_announce_release_subject_and_body_does_not_expand_injected_tag(mo
     release = SimpleNamespace(key="myproject-1.0.0", committee=committee, project=project)
     revision = SimpleNamespace(number="1", tag="{{YOUR_FULL_NAME}}")
 
-    monkeypatch.setattr(
-        construct.config,
-        "get",
-        lambda: SimpleNamespace(APP_HOST="downloads.apache.org", SVN_PUBLISH_URL=None),
-    )
     monkeypatch.setattr(construct.db, "session", _mock_session_factory(MockDBSession(release, revision)))
 
     _subject, body = await construct.announce_release_subject_and_body(
@@ -91,7 +86,7 @@ async def test_announce_release_subject_and_body_does_not_expand_injected_tag(mo
 
 
 @pytest.mark.asyncio
-async def test_announce_release_subject_and_body_uses_podling_downloads_url(monkeypatch) -> None:
+async def test_announce_release_subject_and_body_uses_podling_canonical_downloads_url(monkeypatch) -> None:
     committee = SimpleNamespace(key="myproject", is_podling=True, display_name="Apache MyProject (podling)")
     project = SimpleNamespace(
         short_display_name="Apache MyProject",
@@ -107,11 +102,6 @@ async def test_announce_release_subject_and_body_uses_podling_downloads_url(monk
     release = SimpleNamespace(key="myproject-1.0.0", committee=committee, project=project)
     revision = SimpleNamespace(number="1", tag=None)
 
-    monkeypatch.setattr(
-        construct.config,
-        "get",
-        lambda: SimpleNamespace(APP_HOST="downloads.apache.org", SVN_PUBLISH_URL=None),
-    )
     monkeypatch.setattr(construct.db, "session", _mock_session_factory(MockDBSession(release, revision)))
 
     subject, body = await construct.announce_release_subject_and_body(
@@ -128,11 +118,11 @@ async def test_announce_release_subject_and_body_uses_podling_downloads_url(monk
     )
 
     assert subject == "Apache MyProject 1.0.0"
-    assert body == "https://downloads.apache.org/downloads/incubator/myproject/apache-myproject-1.0.0/"
+    assert body == "https://downloads.apache.org/incubator/myproject/apache-myproject-1.0.0/"
 
 
 @pytest.mark.asyncio
-async def test_announce_release_subject_and_body_uses_top_level_downloads_url(monkeypatch) -> None:
+async def test_announce_release_subject_and_body_uses_top_level_canonical_downloads_url(monkeypatch) -> None:
     committee = SimpleNamespace(key="myproject", is_podling=False, display_name="Apache MyProject")
     project = SimpleNamespace(
         short_display_name="Apache MyProject",
@@ -148,11 +138,6 @@ async def test_announce_release_subject_and_body_uses_top_level_downloads_url(mo
     release = SimpleNamespace(key="myproject-1.0.0", committee=committee, project=project)
     revision = SimpleNamespace(number="1", tag=None)
 
-    monkeypatch.setattr(
-        construct.config,
-        "get",
-        lambda: SimpleNamespace(APP_HOST="downloads.apache.org", SVN_PUBLISH_URL=None),
-    )
     monkeypatch.setattr(construct.db, "session", _mock_session_factory(MockDBSession(release, revision)))
 
     _subject, body = await construct.announce_release_subject_and_body(
@@ -167,7 +152,7 @@ async def test_announce_release_subject_and_body_uses_top_level_downloads_url(mo
         ),
     )
 
-    assert body == "https://downloads.apache.org/downloads/myproject/"
+    assert body == "https://downloads.apache.org/myproject/"
 
 
 @pytest.mark.asyncio
@@ -195,15 +180,9 @@ async def test_start_vote_subject_and_body_uses_canonical_keys_url(
     async def no_release_policy(_data, _project_key):
         return None
 
-    monkeypatch.setattr(
-        construct.config,
-        "get",
-        lambda: SimpleNamespace(
-            APP_HOST="atr.example.invalid",
-            SVN_PUBLISH_URL="https://svn.example.invalid/repos/dist/atr",
-            SVN_DIST_PUBLIC_URL="https://dist.example.invalid/repos/dist/atr",
-        ),
-    )
+    monkeypatch.setattr(construct.config.get(), "APP_HOST", "atr.example.invalid")
+    monkeypatch.setattr(construct.config.get(), "SVN_PUBLISH_URL", "https://svn.example.invalid/repos/dist/atr")
+    monkeypatch.setattr(construct.config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.example.invalid/repos/dist/atr")
     monkeypatch.setattr(construct.db, "session", _mock_session_factory(MockDBSession(release, revision)))
     monkeypatch.setattr(construct.db, "get_project_release_policy", no_release_policy)
     monkeypatch.setattr(construct.util, "as_url", lambda *_args, **_kwargs: "/example")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -24,6 +24,22 @@ import atr.models.safe as safe
 import atr.paths as paths
 
 
+def test_committee_dist_relpath_for_podling() -> None:
+    committee = types.SimpleNamespace(key="myproject", is_podling=True)
+
+    assert paths.committee_dist_relpath(
+        committee,
+        safe.RelPath("myproject-1.0"),
+        "apache-myproject-1.0.tar.gz",
+    ) == safe.RelPath("incubator/myproject/myproject-1.0/apache-myproject-1.0.tar.gz")
+
+
+def test_committee_dist_relpath_for_top_level_committee() -> None:
+    committee = types.SimpleNamespace(key="myproject", is_podling=False)
+
+    assert paths.committee_dist_relpath(committee) == safe.RelPath("myproject")
+
+
 def test_committee_downloads_dir_for_podling(monkeypatch, tmp_path: pathlib.Path):
     committee = types.SimpleNamespace(key="myproject", is_podling=True)
     monkeypatch.setattr(paths, "get_downloads_dir", lambda: safe.StatePath(tmp_path))
@@ -36,22 +52,6 @@ def test_committee_downloads_dir_for_top_level_committee(monkeypatch, tmp_path: 
     monkeypatch.setattr(paths, "get_downloads_dir", lambda: safe.StatePath(tmp_path))
 
     assert paths.committee_downloads_dir(committee).path == tmp_path / "myproject"
-
-
-def test_committee_downloads_url_for_podling() -> None:
-    committee = types.SimpleNamespace(key="myproject", is_podling=True)
-
-    assert paths.committee_downloads_url("downloads.apache.org", committee) == (
-        "https://downloads.apache.org/downloads/incubator/myproject"
-    )
-
-
-def test_committee_downloads_url_for_top_level_committee() -> None:
-    committee = types.SimpleNamespace(key="myproject", is_podling=False)
-
-    assert paths.committee_downloads_url("downloads.apache.org", committee) == (
-        "https://downloads.apache.org/downloads/myproject"
-    )
 
 
 def test_committee_keys_url_for_podling() -> None:

--- a/tests/unit/test_svn_publish_helpers.py
+++ b/tests/unit/test_svn_publish_helpers.py
@@ -81,25 +81,9 @@ async def test_check_propagation_test_target_url(monkeypatch: pytest.MonkeyPatch
     assert summary.outcomes[0].public_url == f"{config.get().SVN_DIST_PUBLIC_URL}/project/artifact.tar.gz"
 
 
-def test_public_download_url_falls_back_to_self_host_without_svn(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", None)
-    committee = sql.Committee(key="apple", name="Apple", is_podling=False)
-
-    url = util.public_download_url(
-        committee,
-        safe.RelPath("apple-1.0"),
-        util.DownloadFile.ARTIFACT,
-        filename="apple-1.0.tar.gz",
-        host="atr.example",
-    )
-
-    assert url == "https://atr.example/downloads/apple/apple-1.0/apple-1.0.tar.gz"
-
-
 def test_download_url_for_path_uses_archive_when_archived(monkeypatch: pytest.MonkeyPatch) -> None:
-    # An archived release lives on archive.apache.org on every host, so even with no SVN publishing
-    # configured (dev) it comes off the archive rather than the self-hosted fallback. The catalogue
-    # passes the artifact's stored full path, so a retired project resolves under its original dir
+    # The catalogue passes the artifact's stored full path, so a retired project resolves under its
+    # original directory on archive.apache.org regardless of the configured live distribution target.
     monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", None)
 
     url = util.download_url_for_path(
@@ -109,47 +93,69 @@ def test_download_url_for_path_uses_archive_when_archived(monkeypatch: pytest.Mo
     assert url == f"{constants.ARCHIVE_APACHE_URL}/abdera/1.0/apache-abdera-1.0.tar.gz"
 
 
-def test_download_url_for_path_self_hosts_without_svn(monkeypatch: pytest.MonkeyPatch) -> None:
-    # With no SVN publishing (dev), a stored full path is served from ATR's own host
-    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", None)
+def test_download_url_for_path_uses_canonical_host_for_released_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.apache.org/repos/dist/atr")
 
     url = util.download_url_for_path(
-        safe.RelPath("abdera/1.0/apache-abdera-1.0.tar.gz"), util.DownloadFile.ARTIFACT, host="atr.example"
+        safe.RelPath("abdera/1.0/apache-abdera-1.0.tar.gz.asc"), util.DownloadFile.METADATA
     )
 
-    assert url == "https://atr.example/downloads/abdera/1.0/apache-abdera-1.0.tar.gz"
+    assert url == f"{constants.DOWNLOADS_APACHE_URL}/abdera/1.0/apache-abdera-1.0.tar.gz.asc"
 
 
-def test_public_download_url_uses_canonical_host_for_released_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", "https://internal.example.invalid/repos/dist/release")
+def test_download_url_for_path_uses_mirror_for_released_artifact(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", None)
+    monkeypatch.setattr(config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.apache.org/repos/dist/atr")
+
+    url = util.download_url_for_path(safe.RelPath("abdera/1.0/apache-abdera-1.0.tar.gz"), util.DownloadFile.ARTIFACT)
+
+    assert url == f"{constants.CLOSER_LUA_URL}/abdera/1.0/apache-abdera-1.0.tar.gz?action=download"
+
+
+def test_publication_check_url_uses_beta_dist_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.apache.org/repos/dist/atr")
+    committee = sql.Committee(key="apple", name="Apple", is_podling=False)
+
+    url = util.publication_check_url(
+        committee,
+        safe.RelPath("apple-1.0"),
+        util.DownloadFile.ARTIFACT,
+        filename="apple-1.0.tar.gz",
+    )
+
+    assert url == "https://dist.apache.org/repos/dist/atr/apple/apple-1.0/apple-1.0.tar.gz"
+
+
+def test_publication_check_url_uses_canonical_host_for_release_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.apache.org/repos/dist/release")
     committee = sql.Committee(key="apple", name="Apple", is_podling=False)
 
-    url = util.public_download_url(
+    url = util.publication_check_url(
         committee, safe.RelPath("apple-1.0"), util.DownloadFile.METADATA, filename="apple-1.0.tar.gz.asc"
     )
 
     assert url == f"{constants.DOWNLOADS_APACHE_URL}/apple/apple-1.0/apple-1.0.tar.gz.asc"
 
 
-def test_public_download_url_uses_mirror_for_released_artifact(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", "https://internal.example.invalid/repos/dist/release")
+def test_publication_check_url_uses_mirror_for_release_artifact(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.apache.org/repos/dist/release")
     committee = sql.Committee(key="apple", name="Apple", is_podling=False)
 
-    url = util.public_download_url(
+    url = util.publication_check_url(
         committee, safe.RelPath("apple-1.0"), util.DownloadFile.ARTIFACT, filename="apple-1.0.tar.gz"
     )
 
     assert url == f"{constants.CLOSER_LUA_URL}/apple/apple-1.0/apple-1.0.tar.gz?action=download"
 
 
-def test_public_download_url_uses_svn_dist_area_for_beta_target(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_publication_check_url_uses_svn_dist_area_for_beta_target(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", "https://internal.example.invalid/repos/dist/atr")
     monkeypatch.setattr(config.get(), "SVN_DIST_PUBLIC_URL", "https://dist.apache.org/repos/dist/atr")
     committee = sql.Committee(key="apple", name="Apple", is_podling=False)
 
-    url = util.public_download_url(committee, safe.RelPath("apple-1.0"), util.DownloadFile.METADATA)
+    url = util.publication_check_url(committee, safe.RelPath("apple-1.0"), util.DownloadFile.METADATA)
 
     assert url == "https://dist.apache.org/repos/dist/atr/apple/apple-1.0"
 


### PR DESCRIPTION
@alitheg This makes announcement emails use `downloads.apache.org` instead of `/downloads/` and changes the catalogue to use the same when it would have used `/downloads/`. One consequence is that in local development we can't really browse what has been published, because it's now expecting things to be published to SVN. We are still moving the finished files to `/finished/`, but it's not exposed, and I think in a subsequent change I might change that to just be attestable data instead. What do you think? And are there any problems with this PR? It affects the catalogue.
