### PR TITLE
fix: In ReleaseManager.record() (atr/storage/writers/distributions.py)

### DIFF
--- a/atr/storage/writers/distributions.py
+++ b/atr/storage/writers/distributions.py
@@ -223,6 +223,10 @@ class ReleaseManager(CommitteeParticipant):
                 return existing, False
             else:
                 existing.pending = False
+                existing.staging = staging
+                existing.upload_date = upload_date
+                existing.api_url = api_url
+                existing.web_url = web_url
                 await self.__data.commit()
                 return existing, False
         return dist, False

--- a/tests/unit/test_release_manager_writer_surface.py
+++ b/tests/unit/test_release_manager_writer_surface.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import unittest.mock as mock
 from types import SimpleNamespace
 
@@ -50,6 +51,7 @@ def active_project(committee_key: str = "alpha") -> SimpleNamespace:
         status=sql.ProjectStatus.ACTIVE,
         committee_key=committee_key,
         release_policy=None,
+        is_active=True,
     )
 
 
@@ -148,6 +150,49 @@ async def test_distribution_record_rejects_foreign_committee() -> None:
             False,
             None,
         )
+
+
+@pytest.mark.asyncio
+async def test_distribution_record_confirms_pending_and_updates_metadata() -> None:
+    upload_date = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+    existing = SimpleNamespace(
+        pending=True,
+        staging=False,
+        retries=0,
+        upload_date=None,
+        api_url=None,
+        web_url=None,
+        created_by=None,
+    )
+    data = mock.MagicMock()
+    data.release = mock.MagicMock(return_value=Query(release_row("alpha")))
+    data.distribution = mock.MagicMock(return_value=Query(existing))
+    data.commit = mock.AsyncMock()
+    writer = object.__new__(distributions.ReleaseManager)
+    writer._ReleaseManager__write = mock.MagicMock()
+    writer._ReleaseManager__data = data
+    writer._ReleaseManager__asf_uid = "alice"
+    writer._ReleaseManager__committee_key = "alpha"
+
+    updated, added = await writer.record(
+        safe.ReleaseKey("example-1.0.0"),
+        sql.DistributionPlatform.MAVEN,
+        None,
+        safe.Alphanumeric("pkg"),
+        safe.VersionKey("1.0.0"),
+        False,
+        False,
+        upload_date,
+        api_url="https://example.test/api",
+        web_url="https://example.test/web",
+    )
+
+    assert added is False
+    assert updated is existing
+    assert existing.pending is False
+    assert existing.upload_date == upload_date
+    assert existing.api_url == "https://example.test/api"
+    assert existing.web_url == "https://example.test/web"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1368

## Pull request summary <!-- markdownlint-disable-line MD041 -->

**Meaningful subject (required):**

<!--
Provide a clear, concise subject line.

Good:
  "Fix schema endpoint auth bypass for OpenAPI"
  "Refactor report authorization filters"

Bad:
  "Fix"
  "Updates"
-->

**Description:**

<!-- Explain what this PR changes and why -->

---

## Required acknowledgements

Please replace each `[ ]` with `[x]` to confirm.
PRs missing confirmations may be closed or converted to Draft.

* [ ] I have read and followed **CONTRIBUTING.md**
* [ ] I have read **DEVELOPMENT.md**
* [ ] I have run the required tests and checks locally
* [ ] All required checks are currently passing
* [ ] This branch is **rebased on the current `main` branch**

---

## Draft requirement

If **any** of the following are true:

* Tests or checks are failing
* Work is incomplete
* Rebase on `main` is pending

**This PR MUST be opened or converted to a Draft**:

Convert to a ready PR only after all acknowledgements above can be confirmed.

---

## Rebase confirmation details (optional but encouraged)

<!--
If helpful, note how the rebase was done:
  git fetch origin
  git rebase origin/main
-->

---

## Additional notes

<!--
Anything reviewers should know:
- Design decisions
- Follow-up work
- Compatibility concerns
-->

---

In ReleaseManager.record() (atr/storage/writers/distributions.py), the pending->confirmed branch (existing.pending and not pending) only flipped existing.pending to False without persisting the newly-resolved staging/upload_date/api_url/web_url, so record_from_data's confirmed metadata was silently dropped; now those fields are assigned before commit, mirroring __upgrade_staging_to_final. Added a regression test in tests/unit/test_release_manager_writer_surface.py that reproduces the bug (failed before the fix, passes after).

**How this was tested:** `make your changes** following our [code conventions](https://release-test.apache.org/docs/code-conventions)`