### PR TITLE
fix: Replaced the negative 'has any scheme' check in to_uri_list with a

### DIFF
--- a/atr/form.py
+++ b/atr/form.py
@@ -51,6 +51,10 @@ DISCRIMINATOR: Final[Any] = schema.discriminator(DISCRIMINATOR_NAME)
 
 _CONFIRM_PATTERN = re.compile(r"^[A-Za-z0-9 _.,!?-]+$")
 
+_URI_LIST_ALLOWED_SCHEMES: Final[frozenset[str]] = frozenset(
+    {"http", "https", "git", "git+ssh", "git+https", "ssh", "svn", "mailto"}
+)
+
 
 class Form(schema.Form):
     pass
@@ -510,10 +514,10 @@ def to_uri_list(v: Any) -> list[str]:
     else:
         raise ValueError(f"Expected a string or list of URIs, got {type(v).__name__}")
 
-    # We accept any URI scheme here rather than leaning on pydantic's AnyUrl,
-    # which rejects VCS locators like git+ssh://git@host:path. urlsplit just needs a scheme to
-    # be present, and we keep each entry exactly as given.
-    invalid = [item for item in items if not parse.urlsplit(item).scheme]
+    # We check against an allowlist of schemes here rather than leaning on pydantic's AnyUrl,
+    # which rejects VCS locators like git+ssh://git@host:path. We keep each entry exactly as
+    # given, but reject dangerous schemes such as javascript: and data:.
+    invalid = [item for item in items if parse.urlsplit(item).scheme.lower() not in _URI_LIST_ALLOWED_SCHEMES]
     if invalid:
         raise ValueError(f"Invalid URI{'s' if len(invalid) > 1 else ''}: {', '.join(invalid)}")
     return items

--- a/tests/unit/test_uri_list.py
+++ b/tests/unit/test_uri_list.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import atr.form as form
+
+
+def test_to_uri_list_rejects_javascript_scheme() -> None:
+    with pytest.raises(ValueError, match="Invalid URI"):
+        form.to_uri_list("javascript:alert(1)")
+
+
+def test_to_uri_list_rejects_data_scheme() -> None:
+    with pytest.raises(ValueError, match="Invalid URI"):
+        form.to_uri_list("data:text/html,<script>alert(1)</script>")
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://example.com",
+        "https://example.com",
+        "git://example.com/repo.git",
+        "git+ssh://git@example.com/repo.git",
+        "git+https://example.com/repo.git",
+        "ssh://git@example.com/repo.git",
+        "svn://example.com/repo",
+        "mailto:user@example.com",
+    ],
+)
+def test_to_uri_list_accepts_allowed_schemes(uri: str) -> None:
+    assert form.to_uri_list(uri) == [uri]
+
+
+def test_to_uri_list_accepts_multiple_lines_of_allowed_schemes() -> None:
+    value = "https://example.com/one\nhttps://example.com/two"
+    assert form.to_uri_list(value) == ["https://example.com/one", "https://example.com/two"]
+
+
+def test_to_uri_list_rejects_mixed_valid_and_dangerous_schemes() -> None:
+    with pytest.raises(ValueError, match="Invalid URI"):
+        form.to_uri_list("https://example.com\njavascript:alert(1)")


### PR DESCRIPTION
Fixes #1359

## Pull request summary <!-- markdownlint-disable-line MD041 -->

**Meaningful subject (required):**

<!--
Provide a clear, concise subject line.

Good:
  "Fix schema endpoint auth bypass for OpenAPI"
  "Refactor report authorization filters"

Bad:
  "Fix"
  "Updates"
-->

**Description:**

<!-- Explain what this PR changes and why -->

---

## Required acknowledgements

Please replace each `[ ]` with `[x]` to confirm.
PRs missing confirmations may be closed or converted to Draft.

* [ ] I have read and followed **CONTRIBUTING.md**
* [ ] I have read **DEVELOPMENT.md**
* [ ] I have run the required tests and checks locally
* [ ] All required checks are currently passing
* [ ] This branch is **rebased on the current `main` branch**

---

## Draft requirement

If **any** of the following are true:

* Tests or checks are failing
* Work is incomplete
* Rebase on `main` is pending

**This PR MUST be opened or converted to a Draft**:

Convert to a ready PR only after all acknowledgements above can be confirmed.

---

## Rebase confirmation details (optional but encouraged)

<!--
If helpful, note how the rebase was done:
  git fetch origin
  git rebase origin/main
-->

---

## Additional notes

<!--
Anything reviewers should know:
- Design decisions
- Follow-up work
- Compatibility concerns
-->

---

Replaced the negative 'has any scheme' check in to_uri_list with a positive scheme allowlist (http, https, git, git+ssh, git+https, ssh, svn, mailto), so javascript: and data: URIs are now rejected while legitimate repository/standards URLs still validate.

**How this was tested:** `make your changes** following our [code conventions](https://release-test.apache.org/docs/code-conventions)`