### PR TITLE
Prevent stale task workers from overwriting newer task results

### DIFF
--- a/atr/db/__init__.py
+++ b/atr/db/__init__.py
@@ -995,6 +995,7 @@ class Session(sqlalchemy.ext.asyncio.AsyncSession):
         added: Opt[datetime.datetime] = NOT_SET,
         started: Opt[datetime.datetime | None] = NOT_SET,
         pid: Opt[int | None] = NOT_SET,
+        execution_generation: Opt[int] = NOT_SET,
         completed: Opt[datetime.datetime | None] = NOT_SET,
         result: Opt[Any | None] = NOT_SET,
         error: Opt[str | None] = NOT_SET,
@@ -1027,6 +1028,8 @@ class Session(sqlalchemy.ext.asyncio.AsyncSession):
             query = query.where(sql.Task.started == started)
         if is_defined(pid):
             query = query.where(sql.Task.pid == pid)
+        if is_defined(execution_generation):
+            query = query.where(sql.Task.execution_generation == execution_generation)
         if is_defined(completed):
             query = query.where(sql.Task.completed == completed)
         if is_defined(result):

--- a/atr/manager.py
+++ b/atr/manager.py
@@ -248,25 +248,43 @@ class WorkerManager:
         await self.reset_broken_tasks()
 
     async def terminate_long_running_task(
-        self, active_task: sql.Task, worker: WorkerProcess, task_id: int, pid: int, limit: float
-    ) -> None:
+        self, data: db.Session, worker: WorkerProcess, task_id: int, pid: int, execution_generation: int, limit: float
+    ) -> sql.Task | None:
         """
         Terminate a task that has been running for too long.
         Updates the task status and terminates the worker process.
         """
-        try:
-            # Mark the task as failed
-            active_task.status = sql.TaskStatus.FAILED
-            active_task.completed = datetime.datetime.now(datetime.UTC)
-            active_task.error = f"Task terminated after exceeding time limit of {limit} seconds"
+        error = f"Task terminated after exceeding time limit of {limit} seconds"
+        update_stmt = (
+            sqlmodel.update(sql.Task)
+            .where(
+                sqlmodel.and_(
+                    sql.Task.id == task_id,
+                    sql.Task.status == sql.TaskStatus.ACTIVE,
+                    sql.Task.pid == pid,
+                    sql.Task.execution_generation == execution_generation,
+                )
+            )
+            .values(
+                status=sql.TaskStatus.FAILED,
+                completed=datetime.datetime.now(datetime.UTC),
+                error=error,
+            )
+            .returning(sql.Task)
+        )
+        failed_task = (await data.execute(update_stmt)).scalar_one_or_none()
+        if failed_task is None:
+            return None
 
-            if worker.pid:
+        if worker.pid:
+            try:
                 os.killpg(worker.pid, signal.SIGTERM)
                 log.info(f"Worker {pid} terminated after processing task {task_id} for > {limit}s")
-        except ProcessLookupError:
-            return
-        except Exception as e:
-            log.error(f"Error stopping long-running worker {pid}: {e}")
+            except ProcessLookupError:
+                ...
+            except Exception as e:
+                log.error(f"Error stopping long-running worker {pid}: {e}")
+        return failed_task
 
     async def check_task_duration(self, data: db.Session, pid: int, worker: WorkerProcess) -> bool:
         """
@@ -285,15 +303,19 @@ class WorkerManager:
                 if task_duration <= limit:
                     return False
 
-                await self.terminate_long_running_task(active_task, worker, active_task.id, pid, limit)
+                failed_task = await self.terminate_long_running_task(
+                    data, worker, active_task.id, pid, active_task.execution_generation, limit
+                )
+                if failed_task is None:
+                    return False
                 notify_args = (
-                    active_task.asf_uid,
-                    active_task.task_type,
-                    active_task.project_key,
-                    active_task.version_key,
-                    active_task.revision_number,
-                    active_task.primary_rel_path,
-                    active_task.error or "task terminated",
+                    failed_task.asf_uid,
+                    failed_task.task_type,
+                    failed_task.project_key,
+                    failed_task.version_key,
+                    failed_task.revision_number,
+                    failed_task.primary_rel_path,
+                    failed_task.error or "task terminated",
                 )
         except Exception as e:
             log.error(f"Error checking task duration for worker {pid}: {e}")

--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -738,6 +738,7 @@ class Task(sqlmodel.SQLModel, table=True):
         sa_column=sqlalchemy.Column(UTCDateTime),
     )
     pid: int | None = None
+    execution_generation: int = sqlmodel.Field(default=0)
     completed: datetime.datetime | None = sqlmodel.Field(
         default=None,
         sa_column=sqlalchemy.Column(UTCDateTime),

--- a/atr/worker.py
+++ b/atr/worker.py
@@ -34,6 +34,7 @@ import traceback
 from collections.abc import Awaitable, Callable
 from typing import Any, Final
 
+import sqlalchemy
 import sqlmodel
 
 import atr.constants as constants
@@ -110,10 +111,16 @@ async def _execute_check_task(
     task_args: list[str] | dict[str, Any],
     task_id: int,
     task_type: str,
+    execution_generation: int,
 ) -> results.Results | None:
     log.debug(f"Handler {handler.__name__} expects checks.FunctionArguments, fetching full task details")
     async with db.session() as data:
-        task_obj = await data.task(id=task_id).demand(ValueError(f"Task {task_id} disappeared during processing"))
+        task_obj = await data.task(
+            id=task_id,
+            status=task.ACTIVE,
+            pid=os.getpid(),
+            execution_generation=execution_generation,
+        ).demand(ValueError(f"Task {task_id} is no longer owned by this worker"))
 
     # Validate required fields from the Task object itself
     if task_obj.project_key is None:
@@ -190,10 +197,6 @@ def _setup_logging() -> None:
     )
 
 
-def _task_completed_log(record: dict[str, Any]) -> None:
-    logging.getLogger(_TASK_LOG_LOGGER).info(json.dumps(record, allow_nan=False))
-
-
 def _task_args_for_log(
     task_type: str | sql.TaskType, task_args: list[str] | dict[str, Any]
 ) -> list[str] | dict[str, Any]:
@@ -202,6 +205,10 @@ def _task_args_for_log(
     return {
         key: _TASK_ARG_HIDDEN if (key in _MESSAGE_SEND_SENSITIVE_ARGS) else value for key, value in task_args.items()
     }
+
+
+def _task_completed_log(record: dict[str, Any]) -> None:
+    logging.getLogger(_TASK_LOG_LOGGER).info(json.dumps(record, allow_nan=False))
 
 
 def _task_completed_record(
@@ -221,20 +228,14 @@ def _task_completed_record(
     }
 
 
-async def _task_defer(task_id: int) -> None:
+async def _task_defer(task_id: int, execution_generation: int) -> None:
     via = sql.validate_instrumented_attribute
     scheduled = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=_DEFER_SECONDS)
     async with db.session() as data:
         async with data.begin():
             update_stmt = (
                 sqlmodel.update(sql.Task)
-                .where(
-                    sqlmodel.and_(
-                        via(sql.Task.id) == task_id,
-                        sql.Task.status == task.ACTIVE,
-                        via(sql.Task.pid) == os.getpid(),
-                    )
-                )
+                .where(_task_owned_by_this_worker(task_id, execution_generation))
                 .values(status=task.QUEUED, started=None, pid=None, scheduled=scheduled)
                 .returning(via(sql.Task.id))
             )
@@ -243,7 +244,7 @@ async def _task_defer(task_id: int) -> None:
                 log.warning(f"Task {task_id} was not deferred because it is no longer active")
 
 
-async def _task_next_claim() -> tuple[int, str, list[str] | dict[str, Any], str] | None:
+async def _task_next_claim() -> tuple[int, str, list[str] | dict[str, Any], str, int] | None:
     """
     Attempt to claim the oldest unclaimed task.
     Returns (task_id, task_type, task_args) if successful.
@@ -273,13 +274,21 @@ async def _task_next_claim() -> tuple[int, str, list[str] | dict[str, Any], str]
             now = datetime.datetime.now(datetime.UTC)
             update_stmt = (
                 sqlmodel.update(sql.Task)
-                .where(sqlmodel.and_(sql.Task.id == oldest_queued_task, sql.Task.status == task.QUEUED))
-                .values(status=task.ACTIVE, started=now, pid=os.getpid())
+                .where(
+                    sqlmodel.and_(sql.Task.id == oldest_queued_task.scalar_subquery(), sql.Task.status == task.QUEUED)
+                )
+                .values(
+                    status=task.ACTIVE,
+                    started=now,
+                    pid=os.getpid(),
+                    execution_generation=via(sql.Task.execution_generation) + 1,
+                )
                 .returning(
-                    sql.validate_instrumented_attribute(sql.Task.id),
-                    sql.validate_instrumented_attribute(sql.Task.task_type),
-                    sql.validate_instrumented_attribute(sql.Task.task_args),
-                    sql.validate_instrumented_attribute(sql.Task.asf_uid),
+                    via(sql.Task.id),
+                    via(sql.Task.task_type),
+                    via(sql.Task.task_args),
+                    via(sql.Task.asf_uid),
+                    via(sql.Task.execution_generation),
                 )
             )
 
@@ -287,14 +296,30 @@ async def _task_next_claim() -> tuple[int, str, list[str] | dict[str, Any], str]
             claimed_task = result.first()
 
             if claimed_task:
-                task_id, task_type, task_args, asf_uid = claimed_task
+                task_id, task_type, task_args, asf_uid, execution_generation = claimed_task
                 log.info(f"Claimed task {task_id} ({task_type}) with args {_task_args_for_log(task_type, task_args)}")
-                return task_id, task_type, task_args, asf_uid
+                return task_id, task_type, task_args, asf_uid, execution_generation
 
             return None
 
 
-async def _task_process(task_id: int, task_type: str, task_args: list[str] | dict[str, Any], asf_uid: str) -> None:
+def _task_owned_by_this_worker(task_id: int, execution_generation: int) -> sqlalchemy.ColumnElement[bool]:
+    via = sql.validate_instrumented_attribute
+    return sqlmodel.and_(
+        via(sql.Task.id) == task_id,
+        sql.Task.status == task.ACTIVE,
+        via(sql.Task.pid) == os.getpid(),
+        sql.Task.execution_generation == execution_generation,
+    )
+
+
+async def _task_process(
+    task_id: int,
+    task_type: str,
+    task_args: list[str] | dict[str, Any],
+    asf_uid: str,
+    execution_generation: int,
+) -> None:
     """Process a claimed task."""
     import atr.config as config
 
@@ -303,7 +328,7 @@ async def _task_process(task_id: int, task_type: str, task_args: list[str] | dic
         task_type_member = sql.TaskType(task_type)
     except ValueError as e:
         log.error(f"Invalid task type: {task_type}")
-        await _task_result_process(task_id, None, task.FAILED, str(e))
+        await _task_result_process(task_id, execution_generation, None, task.FAILED, str(e))
         return
 
     task_results: results.Results | None
@@ -317,7 +342,7 @@ async def _task_process(task_id: int, task_type: str, task_args: list[str] | dic
                 user_account = await ldap.account_lookup(asf_uid)
             except ldap.UnavailableError as e:
                 log.warning(f"Deferring task {task_id} ({task_type}) because LDAP is unavailable: {e}")
-                await _task_defer(task_id)
+                await _task_defer(task_id, execution_generation)
                 return
             # We check here to see if the account is banned - in the case of running tasks,
             # we don't really need to worry about admin/membership status as that wouldn't
@@ -331,7 +356,7 @@ async def _task_process(task_id: int, task_type: str, task_args: list[str] | dic
 
         # Check whether the handler is a check handler
         if (len(params) == 1) and (params[0].annotation == checks.FunctionArguments):
-            handler_result = await _execute_check_task(handler, task_args, task_id, task_type)
+            handler_result = await _execute_check_task(handler, task_args, task_id, task_type, execution_generation)
         else:
             # Otherwise, it's not a check handler
             additional_kwargs = {}
@@ -344,7 +369,7 @@ async def _task_process(task_id: int, task_type: str, task_args: list[str] | dic
         error = None
     except task.DeferredError:
         log.info(f"Task {task_id} ({task_type}) deferred, re-queued for a later attempt")
-        await _task_defer(task_id)
+        await _task_defer(task_id, execution_generation)
         return
     except Exception as e:
         task_results = None
@@ -352,43 +377,65 @@ async def _task_process(task_id: int, task_type: str, task_args: list[str] | dic
         error_details = traceback.format_exc()
         log.error(f"Task {task_id} failed processing: {error_details}")
         error = str(e)
-    await _task_result_process(task_id, task_results, status, error)
+    await _task_result_process(task_id, execution_generation, task_results, status, error)
 
 
 async def _task_result_process(
-    task_id: int, task_results: results.Results | None, status: sql.TaskStatus, error: str | None = None
+    task_id: int,
+    execution_generation: int,
+    task_results: results.Results | None,
+    status: sql.TaskStatus,
+    error: str | None = None,
 ) -> None:
     """Process and store task results in the database."""
     notify_args: tuple[str | None, sql.TaskType, str | None, str | None, str | None, str | None, str] | None = None
     log_record: dict[str, Any] | None = None
     completed = datetime.datetime.now(datetime.UTC)
+    via = sql.validate_instrumented_attribute
+    ownership = _task_owned_by_this_worker(task_id, execution_generation)
     async with db.session() as data:
         async with data.begin():
-            # Find the task by ID
-            task_obj = await data.task(id=task_id).get()
-            if task_obj:
-                if (status == task.COMPLETED) and (task_obj.task_type in task.RECURRING_TASK_TYPES):
-                    # A successful recurring run leaves only a log line behind
+            task_obj = None
+            if status == task.COMPLETED:
+                # A successful recurring run leaves only a log line behind
+                delete_stmt = (
+                    sqlmodel.delete(sql.Task)
+                    .where(
+                        ownership,
+                        via(sql.Task.task_type).in_(task.RECURRING_TASK_TYPES),
+                    )
+                    .returning(sql.Task)
+                )
+                task_obj = (await data.execute(delete_stmt)).scalar_one_or_none()
+                if task_obj is not None:
                     log_record = _task_completed_record(task_obj, task_results, completed)
-                    await data.delete(task_obj)
-                else:
-                    # Update task properties
-                    task_obj.status = status
-                    task_obj.completed = completed
-                    task_obj.result = task_results
 
-                    if status == task.FAILED:
-                        normalised_error = ((error or "").strip()) or "unknown error"
-                        task_obj.error = normalised_error
-                        notify_args = (
-                            task_obj.asf_uid,
-                            task_obj.task_type,
-                            task_obj.project_key,
-                            task_obj.version_key,
-                            task_obj.revision_number,
-                            task_obj.primary_rel_path,
-                            normalised_error,
-                        )
+            if task_obj is None:
+                normalised_error = ((error or "").strip()) or "unknown error"
+                values: dict[str, Any] = {
+                    "status": status,
+                    "completed": completed,
+                    "result": task_results,
+                }
+                if status == task.FAILED:
+                    values["error"] = normalised_error
+                update_stmt = sqlmodel.update(sql.Task).where(ownership).values(**values).returning(sql.Task)
+                task_obj = (await data.execute(update_stmt)).scalar_one_or_none()
+                if (task_obj is not None) and (status == task.FAILED):
+                    notify_args = (
+                        task_obj.asf_uid,
+                        task_obj.task_type,
+                        task_obj.project_key,
+                        task_obj.version_key,
+                        task_obj.revision_number,
+                        task_obj.primary_rel_path,
+                        normalised_error,
+                    )
+
+            if task_obj is None:
+                log.warning(
+                    f"Task {task_id} generation {execution_generation} result was discarded because ownership changed"
+                )
 
     if log_record is not None:
         _task_completed_log(log_record)
@@ -406,9 +453,9 @@ async def _worker_loop_run() -> None:
             log.add_context(worker_pid=os.getpid())
             task = await _task_next_claim()
             if task:
-                task_id, task_type, task_args, asf_uid = task
+                task_id, task_type, task_args, asf_uid, execution_generation = task
                 log.add_context(task_id=task_id, task_type=task_type, asf_uid=asf_uid)
-                await _task_process(task_id, task_type, task_args, asf_uid)
+                await _task_process(task_id, task_type, task_args, asf_uid, execution_generation)
                 processed += 1
                 # Only process max_to_process tasks and then exit
                 # This prevents memory leaks from accumulating

--- a/migrations/versions/0113_2026.07.27_da069f20.py
+++ b/migrations/versions/0113_2026.07.27_da069f20.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add task execution generation
+
+Revision ID: 0113_2026.07.27_da069f20
+Revises: 0112_2026.07.22_d374db02
+Create Date: 2026-07-27 16:16:38.824086+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "0113_2026.07.27_da069f20"
+down_revision: str | None = "0112_2026.07.22_d374db02"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("execution_generation", sa.Integer(), nullable=False, server_default="0"))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.drop_column("execution_generation")

--- a/tests/unit/test_task_execution_generation.py
+++ b/tests/unit/test_task_execution_generation.py
@@ -1,0 +1,228 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import os
+import unittest.mock as mock
+from collections.abc import AsyncIterator
+
+import pytest
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+import sqlmodel
+
+import atr.db as db
+import atr.manager as manager
+import atr.models.sql as sql
+import atr.tasks.task as task
+import atr.worker as worker
+
+
+@pytest.fixture
+async def sqlite_sessionmaker() -> AsyncIterator[sqlalchemy.ext.asyncio.async_sessionmaker[db.Session]]:
+    engine = sqlalchemy.ext.asyncio.create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(sqlmodel.SQLModel.metadata.create_all)
+
+    sessionmaker = sqlalchemy.ext.asyncio.async_sessionmaker(bind=engine, class_=db.Session, expire_on_commit=False)
+    yield sessionmaker
+    await engine.dispose()
+
+
+async def test_check_handler_is_not_built_for_stale_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+) -> None:
+    task_id = await _add_task(
+        sqlite_sessionmaker,
+        status=sql.TaskStatus.ACTIVE,
+        pid=os.getpid(),
+        execution_generation=2,
+    )
+    monkeypatch.setattr(worker.db, "session", lambda: sqlite_sessionmaker())
+    handler = mock.AsyncMock()
+    handler.__name__ = "handler"
+
+    with pytest.raises(ValueError, match="no longer owned"):
+        await worker._execute_check_task(handler, {}, task_id, "check", 1)
+
+    handler.assert_not_awaited()
+
+
+async def test_claim_increments_execution_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+) -> None:
+    task_id = await _add_task(sqlite_sessionmaker)
+    monkeypatch.setattr(worker.db, "session", lambda: sqlite_sessionmaker())
+
+    first_claim = await worker._task_next_claim()
+
+    assert first_claim is not None
+    assert first_claim[0] == task_id
+    assert first_claim[4] == 1
+
+    async with sqlite_sessionmaker() as data:
+        task_obj = await data.task(id=task_id).demand(AssertionError("task missing"))
+        task_obj.status = sql.TaskStatus.QUEUED
+        task_obj.started = None
+        task_obj.pid = None
+        await data.commit()
+
+    second_claim = await worker._task_next_claim()
+
+    assert second_claim is not None
+    assert second_claim[0] == task_id
+    assert second_claim[4] == 2
+
+
+async def test_completed_recurring_task_is_deleted(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+) -> None:
+    task_id = await _add_task(
+        sqlite_sessionmaker,
+        status=sql.TaskStatus.ACTIVE,
+        pid=os.getpid(),
+        execution_generation=1,
+    )
+    monkeypatch.setattr(worker.db, "session", lambda: sqlite_sessionmaker())
+    completed_log = mock.Mock()
+    monkeypatch.setattr(worker, "_task_completed_log", completed_log)
+
+    await worker._task_result_process(task_id, 1, None, task.COMPLETED)
+
+    async with sqlite_sessionmaker() as data:
+        assert await data.task(id=task_id).get() is None
+    completed_log.assert_called_once()
+
+
+async def test_completed_task_is_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+) -> None:
+    task_id = await _add_task(
+        sqlite_sessionmaker,
+        status=sql.TaskStatus.ACTIVE,
+        pid=os.getpid(),
+        execution_generation=1,
+        task_type=sql.TaskType.RAT_CHECK,
+    )
+    monkeypatch.setattr(worker.db, "session", lambda: sqlite_sessionmaker())
+
+    await worker._task_result_process(task_id, 1, None, task.COMPLETED)
+
+    async with sqlite_sessionmaker() as data:
+        task_obj = await data.task(id=task_id).demand(AssertionError("task missing"))
+        assert task_obj.status == sql.TaskStatus.COMPLETED
+        assert task_obj.completed is not None
+
+
+async def test_stale_result_cannot_finish_new_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+) -> None:
+    task_id = await _add_task(
+        sqlite_sessionmaker,
+        status=sql.TaskStatus.ACTIVE,
+        pid=os.getpid(),
+        execution_generation=2,
+    )
+    monkeypatch.setattr(worker.db, "session", lambda: sqlite_sessionmaker())
+    notify_failure = mock.AsyncMock()
+    monkeypatch.setattr(worker.task, "notify_failure", notify_failure)
+
+    await worker._task_result_process(task_id, 1, None, task.FAILED, "stale failure")
+
+    async with sqlite_sessionmaker() as data:
+        task_obj = await data.task(id=task_id).demand(AssertionError("task missing"))
+        assert task_obj.status == sql.TaskStatus.ACTIVE
+        assert task_obj.error is None
+    notify_failure.assert_not_awaited()
+
+    await worker._task_result_process(task_id, 2, None, task.FAILED, "current failure")
+
+    async with sqlite_sessionmaker() as data:
+        task_obj = await data.task(id=task_id).demand(AssertionError("task missing"))
+        assert task_obj.status == sql.TaskStatus.FAILED
+        assert task_obj.error == "current failure"
+    notify_failure.assert_awaited_once()
+
+
+async def test_timeout_transition_rejects_stale_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+) -> None:
+    pid = 4242
+    task_id = await _add_task(
+        sqlite_sessionmaker,
+        status=sql.TaskStatus.ACTIVE,
+        pid=pid,
+        execution_generation=2,
+    )
+    worker_manager = manager.WorkerManager()
+    worker_process = mock.Mock(pid=pid)
+    killpg = mock.Mock()
+    monkeypatch.setattr(manager.os, "killpg", killpg)
+
+    async with sqlite_sessionmaker() as data:
+        async with data.begin():
+            failed_task = await worker_manager.terminate_long_running_task(data, worker_process, task_id, pid, 1, 300)
+        assert failed_task is None
+
+    async with sqlite_sessionmaker() as data:
+        task_obj = await data.task(id=task_id).demand(AssertionError("task missing"))
+        assert task_obj.status == sql.TaskStatus.ACTIVE
+    killpg.assert_not_called()
+
+    async with sqlite_sessionmaker() as data:
+        async with data.begin():
+            failed_task = await worker_manager.terminate_long_running_task(data, worker_process, task_id, pid, 2, 300)
+        assert failed_task is not None
+
+    async with sqlite_sessionmaker() as data:
+        task_obj = await data.task(id=task_id).demand(AssertionError("task missing"))
+        assert task_obj.status == sql.TaskStatus.FAILED
+    killpg.assert_called_once_with(pid, manager.signal.SIGTERM)
+
+
+async def _add_task(
+    sessionmaker: sqlalchemy.ext.asyncio.async_sessionmaker[db.Session],
+    *,
+    status: sql.TaskStatus = sql.TaskStatus.QUEUED,
+    pid: int | None = None,
+    execution_generation: int = 0,
+    task_type: sql.TaskType = sql.TaskType.MAINTENANCE,
+) -> int:
+    async with sessionmaker() as data:
+        task_obj = sql.Task(
+            status=status,
+            task_type=task_type,
+            task_args={},
+            asf_uid="test",
+            started=datetime.datetime.now(datetime.UTC) if status == sql.TaskStatus.ACTIVE else None,
+            pid=pid,
+            execution_generation=execution_generation,
+        )
+        data.add(task_obj)
+        await data.commit()
+        assert task_obj.id is not None
+        return task_obj.id

--- a/tests/unit/test_worker_defer.py
+++ b/tests/unit/test_worker_defer.py
@@ -25,6 +25,12 @@ import atr.tasks.task as task
 import atr.worker as worker
 
 
+def test_task_args_for_log_leaves_other_tasks_unchanged() -> None:
+    task_args = {"body": "Not a mail body"}
+
+    assert worker._task_args_for_log(sql.TaskType.MAINTENANCE, task_args) is task_args
+
+
 def test_task_args_for_log_redacts_message_body_and_recipients() -> None:
     task_args = {
         "email_sender": "sender@apache.org",
@@ -54,12 +60,6 @@ def test_task_args_for_log_redacts_message_body_and_recipients() -> None:
     assert task_args["body"] == "Secret body"
 
 
-def test_task_args_for_log_leaves_other_tasks_unchanged() -> None:
-    task_args = {"body": "Not a mail body"}
-
-    assert worker._task_args_for_log(sql.TaskType.MAINTENANCE, task_args) is task_args
-
-
 async def test_task_process_defers_when_ldap_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("atr.config.is_production_mode", lambda: True)
     monkeypatch.setattr("atr.ldap.account_lookup", mock.AsyncMock(side_effect=ldap.UnavailableError("down")))
@@ -68,9 +68,9 @@ async def test_task_process_defers_when_ldap_unavailable(monkeypatch: pytest.Mon
     result_process = mock.AsyncMock()
     monkeypatch.setattr("atr.worker._task_result_process", result_process)
 
-    await worker._task_process(1, sql.TaskType.MESSAGE_SEND.value, {}, "alice")
+    await worker._task_process(1, sql.TaskType.MESSAGE_SEND.value, {}, "alice", 3)
 
-    defer.assert_awaited_once_with(1)
+    defer.assert_awaited_once_with(1, 3)
     result_process.assert_not_awaited()
 
 
@@ -86,7 +86,7 @@ async def test_task_process_fails_when_handler_ldap_unavailable(monkeypatch: pyt
     result_process = mock.AsyncMock()
     monkeypatch.setattr("atr.worker._task_result_process", result_process)
 
-    await worker._task_process(1, sql.TaskType.MESSAGE_SEND.value, {}, "alice")
+    await worker._task_process(1, sql.TaskType.MESSAGE_SEND.value, {}, "alice", 3)
 
     defer.assert_not_awaited()
-    result_process.assert_awaited_once_with(1, None, task.FAILED, "down")
+    result_process.assert_awaited_once_with(1, 3, None, task.FAILED, "down")


### PR DESCRIPTION
This is to prepare for further task work for #1450, but the idea of this PR is to make restarting tasks safer. We can have a situation where stale task workers (e.g. after a server restart; this happens a lot in dev) still exist and work is being done in parallel. If the stale task worker takes longer than the new one, it can overwrite the status etc. in the database. This PR prevents it from doing that, as each task worker gets the current execution generation of the task, and the generation counter is atomically incremented.

Ideally we'd just terminate the old worker processes, but after a restart we have no idea whether the PIDs are of our workers or not. They might have been reallocated. One solution I was thinking about was to have a communication protocol, so that they could be checked directly, but then workers would need some kind of concurrent interrupt processor, and I figured that would be more complicated than it's worth. We do still have pessimistic stale task detection, and I've been thinking about how to improve it.
