### PR TITLE
#1554 - SVN rm on archive

### DIFF
--- a/atr/admin/__init__.py
+++ b/atr/admin/__init__.py
@@ -989,13 +989,20 @@ async def _catalog_release_status_action(committee_key: str, project_key: str, r
     # flag flips, so we render them as small POST buttons rather than a whole confirmation page
     base = f"/admin/catalog/{committee_key}/project/{project_key}/release/{release.version}"
     if release.is_archived:
+        # A tracked source removed the release's files, so restore can't just flip the flag -
+        # only a legacy archival (null source) can be brought back.
+        if release.archive_source is not None:
+            return htpy.span(
+                ".btn.btn-sm.btn-outline-secondary.me-1.disabled",
+                title="Its files have left the distribution area - republish to restore it",
+            )["Restore"]
         return await form.render(
             model_cls=form.Empty,
             action=f"{base}/restore",
             form_classes=".d-inline",
             submit_classes="btn-sm btn-outline-secondary me-1",
             submit_label="Restore",
-            confirm=f"Restore {release.version} to current?",
+            confirm=f"Restore {release.version} to current? Files will not be modified.",
             empty=True,
         )
     return await form.render(
@@ -1004,7 +1011,7 @@ async def _catalog_release_status_action(committee_key: str, project_key: str, r
         form_classes=".d-inline",
         submit_classes="btn-sm btn-outline-warning me-1",
         submit_label="Archive",
-        confirm=f"Archive {release.version}? It stays catalogued but is marked archived.",
+        confirm=f"Archive {release.version}? It will be archived and its files removed from the distribution area.",
         empty=True,
     )
 
@@ -1108,7 +1115,7 @@ async def catalog_release_archive_post(
     """
     URL: POST /catalog/<committee_key>/project/<project_key>/release/<version_key>/archive
 
-    Mark a single catalogued release as archived, leaving its files in place.
+    Mark a single catalogued release as archived and remove its files from the distribution area.
     """
     async with db.session() as data:
         release = await data.release(project_key=str(project_key), version=str(version_key)).demand(

--- a/atr/models/args.py
+++ b/atr/models/args.py
@@ -236,6 +236,14 @@ class SvnPublish(schema.Strict):
     )
 
 
+class SvnUnpublish(schema.Strict):
+    """Arguments for the task to remove an archived release from the SVN dist area."""
+
+    asf_uid: str = schema.description("ASF UID on whose behalf the removal is committed")
+    project_key: safe.ProjectKey = schema.description("Project key in ATR")
+    version_key: safe.VersionKey = schema.description("Version key in ATR")
+
+
 class SyncKeysFromSvn(schema.Strict):
     """Arguments for the task to reflect a committee's SVN KEYS file into ATR."""
 

--- a/atr/models/results.py
+++ b/atr/models/results.py
@@ -255,6 +255,16 @@ class SvnPublish(schema.Strict):
     message: str = schema.description("A short status message describing the publish outcome")
 
 
+class SvnUnpublish(schema.Strict):
+    """Result of the task to remove an archived release from the SVN dist area."""
+
+    kind: Literal["svn_unpublish"] = schema.Field(alias="kind")
+    svn_revision: int | None = schema.description("The SVN revision the removal landed in, or None if nothing remained")
+    message: str = schema.description("A short status message describing the removal outcome")
+    # Files left in dist that may need manual cleanup.
+    leftover: list[str] = schema.factory(list)
+
+
 class VoteAutoResolve(schema.Strict):
     """Result of the task to automatically resolve a vote."""
 
@@ -321,6 +331,7 @@ Results = Annotated[
     | SBOMToolScore
     | SvnImportFiles
     | SvnPublish
+    | SvnUnpublish
     | VoteAutoResolve
     | VoteEndNotify
     | VoteInitiate,

--- a/atr/models/sql.py
+++ b/atr/models/sql.py
@@ -291,6 +291,7 @@ class TaskType(enum.StrEnum):
     SIGNATURE_CHECK = "signature_check"
     SVN_IMPORT_FILES = "svn_import_files"
     SVN_PUBLISH = "svn_publish"
+    SVN_UNPUBLISH = "svn_unpublish"
     SYNC_KEYS_FROM_SVN = "sync_keys_from_svn"
     TARGZ_INTEGRITY = "targz_integrity"
     TARGZ_STRUCTURE = "targz_structure"
@@ -360,6 +361,8 @@ class TaskType(enum.StrEnum):
                 return "SVN import"
             case TaskType.SVN_PUBLISH:
                 return "SVN publish"
+            case TaskType.SVN_UNPUBLISH:
+                return "SVN unpublish"
             case TaskType.SYNC_KEYS_FROM_SVN:
                 return "Sync keys from SVN"
             case TaskType.TARGZ_INTEGRITY:
@@ -422,6 +425,14 @@ class LifecycleEventType(enum.StrEnum):
     EOD = "eod"
     EOS = "eos"
     EOL = "eol"
+
+
+class ArchiveSource(enum.StrEnum):
+    MANUAL = "manual"
+    CAP = "cap"
+    AUTO_PRIOR = "auto_prior"
+    DIST_WATCHER = "dist_watcher"
+    CATALOG_ADMIN = "catalog_admin"
 
 
 # Pydantic models
@@ -1522,6 +1533,8 @@ class Release(sqlmodel.SQLModel, table=True):
     # The archived status. The archived date above can be null while this is true,
     # for a catalogued historical release we know is archived but can't date
     is_archived: bool = sqlmodel.Field(default=False)
+    # Why the release was archived, set alongside is_archived.
+    archive_source: ArchiveSource | None = sqlmodel.Field(default=None)
     activity_at: datetime.datetime = sqlmodel.Field(
         default_factory=lambda: datetime.datetime.now(datetime.UTC),
         sa_column=sqlalchemy.Column(UTCDateTime, nullable=False),

--- a/atr/notify.py
+++ b/atr/notify.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import atr.constants as constants
+import atr.log as log
+import atr.models.sql as sql
+import atr.storage as storage
+
+
+async def user(
+    asf_uid: str,
+    message: str,
+    level: sql.NotificationLevel,
+    link: str | None = None,
+    link_text: str | None = None,
+) -> None:
+    # Record a notification the user sees as a flash next time they load the UI. The system
+    # service has no inbox, so skip it, and a failed notification never fails the caller.
+    if asf_uid == constants.SYSTEM_SERVICE_UID:
+        return
+    try:
+        async with storage.write_as_user_service(asf_uid) as waus:
+            await waus.notifications_create(message, level, link=link, link_text=link_text)
+    except Exception:
+        log.exception("Failed to record notification")

--- a/atr/post/projects.py
+++ b/atr/post/projects.py
@@ -31,9 +31,9 @@ import atr.log as log
 import atr.models.safe as safe
 import atr.models.sql as sql
 import atr.models.unsafe as unsafe
+import atr.notify as notify
 import atr.shared as shared
 import atr.storage as storage
-import atr.tasks.cap as cap
 import atr.util as util
 import atr.web as web
 
@@ -136,7 +136,7 @@ async def complete_approval(
     except storage.AccessError as e:
         return await session.redirect(get.projects.projects, error=f"Error completing {approval.action.value}: {e}")
 
-    await cap.notify(
+    await notify.user(
         approval.requested_by,
         f"Project {project_key} was {approval.action.value}d after CAP approval.",
         sql.NotificationLevel.INFO,

--- a/atr/storage/__init__.py
+++ b/atr/storage/__init__.py
@@ -361,6 +361,14 @@ class WriteAsReleaseFinaliseService(WriteAsSystemService):
         self.release_finalise_published = admin.release.finalise_published_release
 
 
+class WriteAsReleaseUnpublishService(WriteAsSystemService):
+    def __init__(self, write: Write, data: db.Session):
+        super().__init__(write, data)
+        admin = WriteAsFoundationAdmin(write, data)
+        self.release_unpublish_from_svn = admin.release.unpublish_from_svn_execute
+        self.revert_failed_archive = admin.release.revert_failed_archive
+
+
 class WriteAsAutomatedMailService(WriteAsSystemService):
     def __init__(self, write: Write, data: db.Session):
         super().__init__(write, data)

--- a/atr/storage/datatypes.py
+++ b/atr/storage/datatypes.py
@@ -186,6 +186,10 @@ class FailedError(Exception):
     pass
 
 
+class RetryableError(Exception):
+    pass
+
+
 class ContentInvalidError(FailedError):
     pass
 

--- a/atr/storage/writers/announce.py
+++ b/atr/storage/writers/announce.py
@@ -44,6 +44,7 @@ import atr.models.safe as safe
 import atr.models.sql as sql
 import atr.paths as paths
 import atr.storage as storage
+import atr.storage.writers.release as release
 import atr.svn as svn
 import atr.tasks.checks as checks
 import atr.tasks.checks.signature as signature
@@ -389,39 +390,15 @@ class ReleaseManager(CommitteeParticipant):
         version_key: safe.VersionKey,
         release_row: sql.Release,
     ) -> str | None:
-        if release_row.phase != sql.ReleasePhase.RELEASE:
-            return f"Release {project_key!s} {version_key!s} is not in the release phase"
-
-        archive_date = datetime.datetime.now(datetime.UTC)
-        via = sql.validate_instrumented_attribute
-        update_stmt = (
-            sqlmodel.update(sql.Release)
-            .where(via(sql.Release.key) == release_row.key)
-            .where(via(sql.Release.is_archived).is_(False))
-            .values(archived=archive_date, is_archived=True)
+        return await release.archive_release_core(
+            self.__data,
+            self.__write_as,
+            self.__asf_uid,
+            project_key,
+            version_key,
+            release_row,
+            sql.ArchiveSource.AUTO_PRIOR,
         )
-        update_result = await self.__data.execute_query(update_stmt)
-        if getattr(update_result, "rowcount", 0) != 1:
-            return f"Release {project_key!s} {version_key!s} is already archived"
-
-        self.__data.add(
-            sql.LifecycleEvent(
-                project_key=release_row.project_key,
-                cycle_key=release_row.cycle_key,
-                version_key=release_row.key,
-                event=sql.LifecycleEventType.ARCHIVE,
-                effective=archive_date,
-                published=archive_date,
-            )
-        )
-        await self.__data.commit()
-        self.__write_as.append_to_audit_log(
-            asf_uid=self.__asf_uid,
-            project_key=str(project_key),
-            version=str(version_key),
-            archived=archive_date.isoformat(),
-        )
-        return None
 
     async def __check_local_publication_artifacts(
         self,

--- a/atr/storage/writers/catalogue.py
+++ b/atr/storage/writers/catalogue.py
@@ -33,6 +33,7 @@ import atr.shared.catalogue_import as catalogue_import
 import atr.shared.catalogue_rows as catalogue_rows
 import atr.shared.repoint as repoint
 import atr.storage as storage
+import atr.storage.writers.release as release_writer
 
 # SQLite allows 999 bound variables by default, and an artifact key is three of them
 _DELETE_CHUNK: Final[int] = 300
@@ -138,14 +139,6 @@ class FoundationAdmin:
             raise
 
     async def archive_release(self, release_key: safe.ReleaseKey) -> None:
-        await self._set_release_archived(release_key, True)
-        self.__write_as.append_to_audit_log(asf_uid=self.__asf_uid, archived_release=str(release_key))
-
-    async def restore_release(self, release_key: safe.ReleaseKey) -> None:
-        await self._set_release_archived(release_key, False)
-        self.__write_as.append_to_audit_log(asf_uid=self.__asf_uid, restored_release=str(release_key))
-
-    async def _set_release_archived(self, release_key: safe.ReleaseKey, archived: bool) -> None:
         key = str(release_key)
         await self.__data.begin_immediate()
         self.__data.expire_all()
@@ -153,20 +146,46 @@ class FoundationAdmin:
             release = await self.__data.get(sql.Release, key)
             if release is None:
                 raise storage.AccessError(f"Release '{key}' not found.", status=404)
-            if release.is_archived == archived:
-                state = "archived" if archived else "active"
-                raise storage.AccessError(f"Release '{key}' is already {state}.", status=409)
-            # Only the status flag moves. We leave the archived date alone: it mirrors a
-            # lifecycle event, and a catalogued release we archive by hand may well have no
-            # such event, which the model allows (an archived-but-undated release). The flag
-            # feeds both the project's current-versus-archived split and the committee
-            # summary's latest and count, so the whole site regenerates
-            release.is_archived = archived
+            if release.is_archived:
+                raise storage.AccessError(f"Release '{key}' is already archived.", status=409)
+            # A catalogue archive only ever acts on a current release
+            release.is_archived = True
+            release.archive_source = sql.ArchiveSource.CATALOG_ADMIN
+            release_writer.queue_svn_unpublish(self.__data, self.__asf_uid, release)
             await catalog_site.queue_full_regeneration(self.__data, self.__asf_uid)
             await self.__data.commit()
         except Exception:
             await self.__data.rollback()
             raise
+        self.__write_as.append_to_audit_log(asf_uid=self.__asf_uid, archived_release=str(release_key))
+
+    async def restore_release(self, release_key: safe.ReleaseKey) -> None:
+        key = str(release_key)
+        await self.__data.begin_immediate()
+        self.__data.expire_all()
+        try:
+            release = await self.__data.get(sql.Release, key)
+            if release is None:
+                raise storage.AccessError(f"Release '{key}' not found.", status=404)
+            if not release.is_archived:
+                raise storage.AccessError(f"Release '{key}' is already active.", status=409)
+            # Only an existing archival (no tracked source, from before removal existed) left the
+            # files in place, so only they can be brought back.
+            if release.archive_source is not None:
+                raise storage.AccessError(
+                    f"Release '{key}' was removed from the distribution area, so its files"
+                    " are gone and it can't be restored to current; republish it to bring it back.",
+                    status=409,
+                )
+            # Clear the source with the flag, so a later archival records its own reason.
+            release.is_archived = False
+            release.archive_source = None
+            await catalog_site.queue_full_regeneration(self.__data, self.__asf_uid)
+            await self.__data.commit()
+        except Exception:
+            await self.__data.rollback()
+            raise
+        self.__write_as.append_to_audit_log(asf_uid=self.__asf_uid, restored_release=str(release_key))
 
     async def rename_project(self, old_key: safe.ProjectKey, new_key: safe.ProjectKey, new_name: str | None) -> None:
         old = str(old_key)

--- a/atr/storage/writers/release.py
+++ b/atr/storage/writers/release.py
@@ -37,6 +37,7 @@ import sqlalchemy.engine as engine
 import sqlmodel
 
 import atr.analysis as analysis
+import atr.attestable as attestable
 import atr.auditlog as auditlog
 import atr.catalog_site as catalog_site
 import atr.config as config
@@ -49,7 +50,7 @@ import atr.hashes as hashes
 import atr.log as log
 import atr.models.api as api
 import atr.models.args as args
-import atr.models.attestable as attestable
+import atr.models.attestable as attestable_models
 import atr.models.results as results
 import atr.models.safe as safe
 import atr.models.sql as sql
@@ -107,17 +108,17 @@ class DeleteFileResult:
     metadata_files_deleted: int
 
 
-async def _archive_release(
+async def archive_release_core(
     data: db.Session,
     write_as: storage.WriteAs,
     asf_uid: str,
     project_key: safe.ProjectKey,
     version_key: safe.VersionKey,
     release: sql.Release,
+    source: sql.ArchiveSource,
 ) -> str | None:
-    # The archive core, shared by a committee member archiving by hand and the
-    # system archiving a dist removal. Only an announced release can be
-    # archived.
+    # Only an announced release can be archived. The source is recorded so the removal
+    # from SVN can be gated on it and a restore can refuse a release whose files have left dist.
     if release.phase != sql.ReleasePhase.RELEASE:
         return f"Release {project_key!s} {version_key!s} is not in the release phase"
 
@@ -127,13 +128,17 @@ async def _archive_release(
         sqlmodel.update(sql.Release)
         .where(via(sql.Release.key) == release.key)
         .where(via(sql.Release.is_archived).is_(False))
-        .values(archived=archive_date, is_archived=True)
+        .values(archived=archive_date, is_archived=True, archive_source=source)
     )
     update_result = await data.execute_query(update_stmt)
     if getattr(update_result, "rowcount", 0) != 1:
         return f"Release {project_key!s} {version_key!s} is already archived"
 
-    # TODO: SVN move to archive.apache.org goes here once SVN is wired up.
+    # The dist watcher archives a release because its files already left dist, so
+    # there's nothing left to remove - every other source is a live release we're
+    # taking out of the dist area.
+    if source is not sql.ArchiveSource.DIST_WATCHER:
+        queue_svn_unpublish(data, asf_uid, release)
 
     data.add(
         sql.LifecycleEvent(
@@ -201,7 +206,7 @@ async def _claim_release_archive_approval(
     project_key: safe.ProjectKey,
     version_key: safe.VersionKey,
     committee_key: str,
-) -> None:
+) -> str:
     approval = await data.approval_request(id=approval_request_id).get()
     if (approval is None) or (approval.status != sql.ApprovalStatus.APPROVED):
         raise storage.AccessError("This approval request is not ready to complete.", status=409)
@@ -214,6 +219,9 @@ async def _claim_release_archive_approval(
     if approval.committee_key != committee_key:
         raise storage.AccessError("This approval request was filed for a different committee.", status=409)
     approval.status = sql.ApprovalStatus.COMPLETED
+    # The requester is a real committer, so the archival - and the SVN removal it commits -
+    # is attributed to them rather than to the system running the resolve task.
+    return approval.requested_by
 
 
 async def _ensure_project_cycle(data: db.Session, project: sql.Project, version: safe.VersionKey) -> str:
@@ -243,6 +251,36 @@ def _normalise_signature_field(value: object) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def queue_svn_unpublish(data: db.Session, asf_uid: str, release: sql.Release) -> None:
+    # Queue a task to take the release's files out of the dist area.
+    if not config.get().SVN_PUBLISH_URL:
+        return
+    data.add(
+        sql.Task(
+            status=sql.TaskStatus.QUEUED,
+            task_type=sql.TaskType.SVN_UNPUBLISH,
+            task_args=args.SvnUnpublish(
+                asf_uid=asf_uid,
+                project_key=safe.ProjectKey(release.project_key),
+                version_key=safe.VersionKey(release.version),
+            ).model_dump(),
+            asf_uid=asf_uid,
+            project_key=release.project_key,
+            version_key=release.version,
+        )
+    )
+
+
+def _unpublish_svn_error(exc: svn.CommandExecutionError, context: str) -> Exception:
+    # A connection wobble or a stale baseline - a concurrent commit moved a path since we
+    # listed it - clears on a retry, so defer it; anything else is terminal.
+    message = svn.error_message(exc)
+    log.error(f"SVN unpublish {context}: {message}")
+    if svn.retryable_error(exc):
+        return datatypes.RetryableError(message)
+    return datatypes.FailedError(message)
 
 
 async def _signature_provenance_metadata_for(
@@ -671,7 +709,7 @@ class CommitteeParticipant(FoundationCommitter):
 
         async def modify(
             path: safe.StatePath, old_rev: sql.Revision | None
-        ) -> dict[safe.RelPath, attestable.ProvenanceV2] | None:
+        ) -> dict[safe.RelPath, attestable_models.ProvenanceV2] | None:
             # Uses new_revision_number for logging only
             path_in_new_revision = path / rel_path
 
@@ -708,16 +746,16 @@ class CommitteeParticipant(FoundationCommitter):
                 await f.write(f"{hash_value}  {rel_path.name}\n")
 
             generated_rel = safe.RelPath(str(rel_path.parent / hash_path_rel_name))
-            generator = attestable.GeneratorV2.SHA512_FROM_CONTENT
+            generator = attestable_models.GeneratorV2.SHA512_FROM_CONTENT
             metadata: dict[str, Any] = {
                 "initiated_by": self.__asf_uid,
                 "source_content_hashes": {str(rel_path): source_content_hash},
                 "source_paths": [str(rel_path)],
             }
             if signature_metadata is not None:
-                generator = attestable.GeneratorV2.SHA512_FROM_SIGNATURE
+                generator = attestable_models.GeneratorV2.SHA512_FROM_SIGNATURE
                 metadata.update(signature_metadata)
-            provenance = attestable.ProvenanceV2(generator=generator, metadata=metadata)
+            provenance = attestable_models.ProvenanceV2(generator=generator, metadata=metadata)
             return {generated_rel: provenance}
 
         await self.__write_as.revision.create_revision_with_quarantine(
@@ -1476,8 +1514,14 @@ class CommitteeMember(ReleaseManager):
             if release is None:
                 raise storage.AccessError(f"Release {project_key!s} {version_key!s} not found", status=404)
             await self.__assert_archivable_without_vote(project, release, project_key, version_key)
-            error = await _archive_release(
-                self.__data, self.__write_as, self.__asf_uid, project_key, version_key, release
+            error = await archive_release_core(
+                self.__data,
+                self.__write_as,
+                self.__asf_uid,
+                project_key,
+                version_key,
+                release,
+                sql.ArchiveSource.MANUAL,
             )
             if error is not None:
                 raise storage.AccessError(error, status=409)
@@ -1570,7 +1614,6 @@ class FoundationAdmin(FoundationCommitter):
         """Archive an announced release as the system.
 
         Used by the dist watcher when a release directory leaves the dist area.
-        Shares the archive core with the committee-member path, log matches.
         """
         release = await self.__data.release(
             project_key=str(project_key),
@@ -1579,7 +1622,15 @@ class FoundationAdmin(FoundationCommitter):
         ).get()
         if release is None:
             return f"Release {project_key!s} {version_key!s} not found"
-        return await _archive_release(self.__data, self.__write_as, self.__asf_uid, project_key, version_key, release)
+        return await archive_release_core(
+            self.__data,
+            self.__write_as,
+            self.__asf_uid,
+            project_key,
+            version_key,
+            release,
+            sql.ArchiveSource.DIST_WATCHER,
+        )
 
     async def complete_archive(
         self,
@@ -1587,13 +1638,14 @@ class FoundationAdmin(FoundationCommitter):
         version_key: safe.VersionKey,
         approval_request_id: int,
     ) -> str | None:
-        """Archive a release whose CAP approval vote has passed, as the system.
+        """Archive a release whose CAP approval vote has passed.
 
-        The CAP resolve task runs this once a vote passes, so there's no
-        committer in the loop to press the button. It mirrors the by-hand
-        committee-member path: take the write lock, claim the approval, then
-        archive. The lock is taken before the approval is read, so an approval
-        can only ever complete one archival.
+        The CAP resolve task runs this once a vote passes, so there's no committer
+        pressing the button - but the person who requested the vote is a real committer,
+        so the archival, and the SVN removal it commits, is attributed to them rather than
+        to the system. It mirrors the by-hand committee-member path: take the write lock,
+        claim the approval, then archive. The lock is taken before the approval is read, so
+        an approval can only ever complete one archival.
         """
         await self.__data.begin_immediate()
         self.__data.expire_all()
@@ -1608,7 +1660,7 @@ class FoundationAdmin(FoundationCommitter):
             committee = release.committee
             if committee is None:
                 return f"Release {project_key!s} {version_key!s} has no committee"
-            await _claim_release_archive_approval(
+            requested_by = await _claim_release_archive_approval(
                 self.__data, approval_request_id, project_key, version_key, committee.key
             )
             if release.is_archived:
@@ -1617,8 +1669,14 @@ class FoundationAdmin(FoundationCommitter):
                 # blocking the release
                 await self.__data.commit()
                 return None
-            return await _archive_release(
-                self.__data, self.__write_as, self.__asf_uid, project_key, version_key, release
+            return await archive_release_core(
+                self.__data,
+                self.__write_as,
+                requested_by,
+                project_key,
+                version_key,
+                release,
+                sql.ArchiveSource.CAP,
             )
         except storage.AccessError as e:
             await self.__data.rollback()
@@ -1791,6 +1849,217 @@ class FoundationAdmin(FoundationCommitter):
             audit_events=audit_events,
             message=message,
         )
+
+    async def unpublish_from_svn_execute(self, task_args: args.SvnUnpublish) -> results.SvnUnpublish:
+        # The removal is the inverse of the publish - take out the files ATR recorded.
+        publish_url = config.get().SVN_PUBLISH_URL
+        if not publish_url:
+            # The publish target went away between queuing and running, so fail
+            # cleanly rather than let the URL builder raise a bare ValueError.
+            raise datatypes.FailedError("SVN_PUBLISH_URL is not configured")
+        release = await self.__data.release(
+            project_key=str(task_args.project_key),
+            version=str(task_args.version_key),
+            _committee=True,
+            _project_release_policy=True,
+        ).demand(datatypes.FailedError("Release not found for removal"))
+        committee = release.committee
+        if committee is None:
+            raise datatypes.FailedError("Release has no committee - Invalid state")
+
+        # Where ATR published: the release's own suffix if it locked one, else the project policy
+        # default (an empty suffix is the committee root on purpose). Resolved the same way publish
+        # resolves it, so we look where the files actually went rather than at a raw null.
+        effective_suffix = construct.effective_download_path_suffix(release)
+        release_dir = str(paths.committee_dist_relpath(committee, effective_suffix))
+        root_url = publish_url.rstrip("/")
+        pairs, exact, alternatives = await self.__removal_wanted(task_args, release_dir)
+        if not pairs:
+            return results.SvnUnpublish(
+                kind="svn_unpublish", svn_revision=None, message=f"No published files recorded for {release.key}"
+            )
+        # Pin the listing and the removal to one revision. If the dist area moves under us
+        # between the two, svnmucc rejects the whole rm out of date rather than deleting
+        # against a tree we never looked at.
+        base_revision = await self.__dist_base_revision(root_url)
+        if base_revision is None:
+            return results.SvnUnpublish(
+                kind="svn_unpublish", svn_revision=None, message=f"{release.key} was already absent from dist"
+            )
+        rel_paths, leftover = await self.__plan_removals(
+            root_url, release.version, pairs, exact, alternatives, base_revision
+        )
+        if not rel_paths:
+            return results.SvnUnpublish(
+                kind="svn_unpublish", svn_revision=None, message=f"{release.key} was already absent from dist"
+            )
+
+        log_message = (
+            f"Unpublish {task_args.project_key!s}-{task_args.version_key!s}\n\n"
+            f"Committee: {committee.key}\n"
+            "Tool: ATR\n"
+            f"Archived by {task_args.asf_uid} via ATR"
+        )
+        try:
+            output = await svn.remove_files(
+                root_url, rel_paths, task_args.asf_uid, log_message, base_revision=base_revision
+            )
+        except svn.CommandExecutionError as exc:
+            raise _unpublish_svn_error(exc, "removal failed") from None
+        revision = svn.parse_svnmucc_revision(output)
+        self.__write_as.append_to_audit_log(
+            asf_uid=task_args.asf_uid,
+            project_key=str(task_args.project_key),
+            version=str(task_args.version_key),
+            svn_revision=revision,
+        )
+        landed = f" as r{revision}" if revision is not None else ""
+        return results.SvnUnpublish(
+            kind="svn_unpublish",
+            svn_revision=revision,
+            message=f"Removed {len(rel_paths)} file(s) for {release.key} from SVN{landed}",
+            leftover=leftover,
+        )
+
+    async def revert_failed_archive(self, project_key: safe.ProjectKey, version_key: safe.VersionKey) -> None:
+        # The SVN removal for this archival failed terminally. svnmucc is atomic, so the files
+        # are still in dist - the record says archived but the reality is current. Put the
+        # release back to current so the two agree, and retract the archive event rather than
+        # deleting it, since the lifecycle trail is append-only.
+        release = await self.__data.release(project_key=str(project_key), version=str(version_key)).get()
+        if (release is None) or (not release.is_archived):
+            return
+        via = sql.validate_instrumented_attribute
+        prior_event_id = (
+            await self.__data.execute(
+                sqlmodel.select(via(sql.LifecycleEvent.id))
+                .where(
+                    via(sql.LifecycleEvent.version_key) == release.key,
+                    via(sql.LifecycleEvent.event) == sql.LifecycleEventType.ARCHIVE,
+                )
+                .order_by(via(sql.LifecycleEvent.published).desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        release.is_archived = False
+        release.archived = None
+        release.archive_source = None
+        self.__data.add(release)
+        if prior_event_id is not None:
+            now = datetime.datetime.now(datetime.UTC)
+            self.__data.add(
+                sql.LifecycleEvent(
+                    project_key=release.project_key,
+                    cycle_key=release.cycle_key,
+                    version_key=release.key,
+                    event=sql.LifecycleEventType.WITHDRAW,
+                    effective=now,
+                    published=now,
+                    target_event_id=prior_event_id,
+                )
+            )
+        await self.__data.commit()
+        self.__write_as.append_to_audit_log(
+            asf_uid=self.__asf_uid,
+            reverted_failed_archive=release.key,
+        )
+
+    async def __removal_wanted(
+        self, task_args: args.SvnUnpublish, release_dir: str
+    ) -> tuple[list[tuple[str, set[str]]], bool, bool]:
+        # Use the attestable manifest - the full list of files ATR published - and fall back
+        # to the recorded artifact rows for a release that has none (one catalogued or
+        # imported, never published through ATR). exact says whether the set is complete: a
+        # manifest is, the fallback isn't (it omits non-artifact files like a README), so a
+        # fallback removal can leave files behind that the caller flags for cleanup.
+        # alternatives says the directories are candidates for one location, tried newest first
+        # (the manifest case), rather than distinct directories each holding their own files.
+        artifacts = await self.__data.artifact(
+            project_key=str(task_args.project_key), version=str(task_args.version_key)
+        ).all()
+        artifact_dirs = sorted({suffix for artifact in artifacts if (suffix := artifact.download_path_suffix)})
+        revision_number = await attestable.latest_revision_number(task_args.project_key, task_args.version_key)
+        if revision_number is not None:
+            manifest = await attestable.load(task_args.project_key, task_args.version_key, revision_number)
+            if manifest is not None:
+                # Where the artifact rows say the files sit
+                # Project policy path (release_dir) as a fallback for releases moved by hand in alpha
+                # dist directly.
+                names = set(manifest.paths.keys())
+                ordered: list[str] = []
+                for directory in [*artifact_dirs, release_dir]:
+                    if directory not in ordered:
+                        ordered.append(directory)
+                return [(directory, names) for directory in ordered], True, True
+        wanted: dict[str, set[str]] = {}
+        for artifact in artifacts:
+            directory = artifact.download_path_suffix or release_dir
+            for name in (artifact.artifact_path, artifact.signature_path, artifact.checksum_path, artifact.sbom_path):
+                if name:
+                    wanted.setdefault(directory, set()).add(name)
+        return list(wanted.items()), False, False
+
+    async def __dist_base_revision(self, root_url: str) -> int | None:
+        # The revision the removal plans against - the dist area's current head. None means
+        # the whole area is already gone, so there's nothing to unpublish.
+        try:
+            info = await svn.SvnInfo.from_url(root_url)
+        except svn.CommandExecutionError as exc:
+            if svn.path_missing_error(exc):
+                return None
+            raise _unpublish_svn_error(exc, "base revision lookup failed") from None
+        return info.revision_number
+
+    async def __plan_removals(
+        self,
+        root_url: str,
+        version: str,
+        pairs: list[tuple[str, set[str]]],
+        exact: bool,
+        alternatives: bool,
+        base_revision: int,
+    ) -> tuple[list[str], list[str]]:
+        # Keep only what's still in the dist area, so a re-run or a partial earlier removal is
+        # idempotent: svnmucc is atomic and would fail the whole commit on an already-gone path.
+        rel_paths: list[str] = []
+        leftover: list[str] = []
+        for directory, names in pairs:
+            # Recursive listing finds the files wherever the release put them, nested or
+            # not. A directory that holds nothing but our files - a version directory the
+            # release owns outright - comes out whole. A shared directory (the committee root, or
+            # a flat category dir like plugins/) may hold other releases, so there we only take
+            # our own files. The non-empty guard stops an empty listing removing a phantom path.
+            present = await self.__list_present(f"{root_url}/{directory}", base_revision)
+            if present is None:
+                continue
+            found: list[str] = []
+            if present and (present <= names):
+                found.append(directory)
+            else:
+                found.extend(f"{directory}/{name}" for name in sorted(names) if name in present)
+                # Files a fallback removal missed are worth flagging only in the release's own
+                # directory - one carrying its version. A shared category dir (plugins/, providers/)
+                # holds siblings, not our leftovers, so we say nothing there.
+                if (not exact) and (version in directory):
+                    leftover.extend(f"{directory}/{other}" for other in sorted(present - names))
+            if found:
+                rel_paths.extend(found)
+                # When the directories are candidates for one location the files sit in the first
+                # that has them; stop, so a stale duplicate elsewhere is left alone.
+                if alternatives:
+                    break
+        return sorted(rel_paths), sorted(leftover)
+
+    async def __list_present(self, url: str, revision: int) -> set[str] | None:
+        # None means the path simply isn't there - already gone, so nothing to remove. Any
+        # other error is no proof the path has gone, so it stays a failure. Listing is pinned
+        # to the removal's baseline revision, so the plan and the svnmucc rm see one tree.
+        try:
+            return set(await svn.list_files(url, revision))
+        except svn.CommandExecutionError as exc:
+            if svn.path_missing_error(exc):
+                return None
+            raise _unpublish_svn_error(exc, "listing failed") from None
 
     async def notify_seen(
         self,

--- a/atr/svn/__init__.py
+++ b/atr/svn/__init__.py
@@ -34,12 +34,18 @@ ASF_TOOL: Final[str] = "atr"
 EXPORT_TIMEOUT_SECONDS: Final[float] = 240.0
 INFO_TIMEOUT_SECONDS: Final[float] = 30.0
 KEYS_TIMEOUT_SECONDS: Final[float] = 60.0
-LIST_TIMEOUT_SECONDS: Final[float] = 60.0
+LIST_TIMEOUT_SECONDS: Final[float] = 120.0
 PUBLISH_TIMEOUT_SECONDS: Final[float] = 240.0
 _COMMITTED_REVISION_RE: Final = re.compile(r"^Committed revision (\d+)\.\s*$", re.MULTILINE)
+# svnmucc reports a commit as `r<N> committed by <author> at <date>`, a different
+# shape from the `Committed revision <N>.` line svn import and commit emit.
+_SVNMUCC_REVISION_RE: Final = re.compile(r"^r(\d+) committed by ", re.MULTILINE)
 _CONNECTION_ERROR_CODES: Final[frozenset[str]] = frozenset(
     {"E000110", "E000111", "E120108", "E170013", "E175002", "E175012"}
 )
+# Codes svn emits when a commit's baseline is stale - a concurrent commit moved a
+# targeted path since we listed it.
+_OUT_OF_DATE_CODES: Final[frozenset[str]] = frozenset({"E160028", "E170004"})
 _ERROR_CODE_PRIORITY: Final[tuple[str, ...]] = (
     "E160020",
     "E215004",
@@ -52,6 +58,9 @@ _ERROR_CODE_PRIORITY: Final[tuple[str, ...]] = (
     "E170013",
 )
 _ERROR_CODE_RE: Final = re.compile(r"\bE\d{6}\b")
+# Codes svn emits when a path or URL genuinely isn't in the repository, as
+# opposed to a connection or auth failure.
+_MISSING_PATH_CODES: Final[frozenset[str]] = frozenset({"E160013", "E200009", "W160013", "W170000"})
 _ERROR_SUMMARIES: Final[dict[str, str]] = {
     "E000110": "The connection to the SVN server was reset",
     "E000111": "The connection to the SVN server was refused",
@@ -245,16 +254,22 @@ async def info_authenticated(url: str) -> str:
     )
 
 
-async def list_files(url: str) -> list[str]:
-    """List every file below a URL, as paths relative to it. Directories are left out."""
+async def list_files(url: str, revision: int | None = None) -> list[str]:
+    """List every file below a URL, as paths relative to it. Directories are left out.
+
+    Pass revision to list from a specific point in time. A caller planning changes can
+    then hand the same revision to svnmucc as its baseline, so the commit fails out of
+    date rather than acting on a tree that drifted between the listing and the change.
+    """
+    arguments = ["list"]
+    if revision is not None:
+        # Peg and operate at the one revision, the same shape export uses
+        arguments.extend(["-r", str(revision), f"{url}@{revision}"])
+    else:
+        arguments.append(url)
+    arguments.extend(["--recursive", "--username", ASF_TOOL, "--password-from-stdin", "--non-interactive"])
     output = await _run_svn_command(
-        "list",
-        url,
-        "--recursive",
-        "--username",
-        ASF_TOOL,
-        "--password-from-stdin",
-        "--non-interactive",
+        *arguments,
         timeout_seconds=LIST_TIMEOUT_SECONDS,
         stdin_bytes=_authentication(url),
     )
@@ -265,6 +280,32 @@ def parse_committed_revision(output: str) -> int | None:
     if (match := _COMMITTED_REVISION_RE.search(output)) is None:
         return None
     return int(match.group(1))
+
+
+def parse_svnmucc_revision(output: str) -> int | None:
+    if (match := _SVNMUCC_REVISION_RE.search(output)) is None:
+        return None
+    return int(match.group(1))
+
+
+def path_missing_error(exc: CommandExecutionError) -> bool:
+    """Whether the error says the path or URL simply isn't in the repository.
+
+    Matches only on svn's own error codes, never on free text: a connection or
+    auth failure, or a timeout (which carries no code), reads as False and stays
+    a real failure, since a transient error is no proof that a path has gone.
+    """
+    return any(code in exc.output for code in _MISSING_PATH_CODES)
+
+
+def retryable_error(exc: CommandExecutionError) -> bool:
+    """Whether the error is worth another attempt rather than a terminal failure.
+
+    A connection wobble, or an out-of-date baseline where a concurrent commit moved a
+    path since we listed it, both tend to clear on a retry, so the task can defer rather
+    than fail. Matches only on svn's own codes, never free text.
+    """
+    return any(code in exc.output for code in (_CONNECTION_ERROR_CODES | _OUT_OF_DATE_CODES))
 
 
 async def publish_file(local_path: pathlib.Path, target_url: str, username: str, message: str) -> None:
@@ -366,14 +407,20 @@ async def publish_revision_matches(info: SvnInfo, author: str, message: str) -> 
     return tool.strip() == ASF_TOOL
 
 
-async def remove_files(base_url: str, rel_paths: list[str], username: str, message: str) -> None:
+async def remove_files(
+    base_url: str, rel_paths: list[str], username: str, message: str, base_revision: int | None = None
+) -> str:
     log.debug(f"running svnmucc rm for user '{username}'")
     stdin_bytes = _authentication(base_url)
-    actions: list[str] = []
+    arguments: list[str] = []
+    if base_revision is not None:
+        # Baseline the commit, so a path that moved since the caller listed it fails the
+        # whole rm out of date rather than deleting against a tree we never saw.
+        arguments.extend(["-r", str(base_revision)])
     for rel_path in rel_paths:
-        actions.extend(["rm", f"{base_url}/{rel_path}"])
-    await _run_svnmucc_command(
-        *actions,
+        arguments.extend(["rm", f"{base_url}/{rel_path}"])
+    return await _run_svnmucc_command(
+        *arguments,
         "--username",
         username,
         "--password-from-stdin",

--- a/atr/tasks/__init__.py
+++ b/atr/tasks/__init__.py
@@ -444,6 +444,8 @@ def resolve(task_type: sql.TaskType) -> Callable[..., Awaitable[results.Results 
             return svn.import_files
         case sql.TaskType.SVN_PUBLISH:
             return svnpub.publish
+        case sql.TaskType.SVN_UNPUBLISH:
+            return svnpub.unpublish
         case sql.TaskType.SYNC_KEYS_FROM_SVN:
             return keys.sync_from_svn
         case sql.TaskType.TARGZ_INTEGRITY:

--- a/atr/tasks/cap.py
+++ b/atr/tasks/cap.py
@@ -25,26 +25,11 @@ import atr.models.cap
 import atr.models.results as results
 import atr.models.safe as safe
 import atr.models.sql as sql
+import atr.notify as notify
 import atr.storage as storage
 import atr.tasks as tasks
 import atr.tasks.checks as checks
 import atr.util as util
-
-
-async def notify(
-    asf_uid: str,
-    message: str,
-    level: sql.NotificationLevel,
-    link: str | None = None,
-    link_text: str | None = None,
-) -> None:
-    if asf_uid == constants.SYSTEM_SERVICE_UID:
-        return
-    try:
-        async with storage.write_as_user_service(asf_uid) as waus:
-            await waus.notifications_create(message, level, link=link, link_text=link_text)
-    except Exception:
-        log.exception("Failed to record CAP notification")
 
 
 @checks.with_model(args.CapApprovalResolveArgs)
@@ -82,7 +67,7 @@ async def _apply_outcome(request_id: int, row: sql.ApprovalRequest, resolution: 
             # A passed archival vote completes itself, so there's no button left to press
             await _complete_release_archival(row)
             return
-        await notify(
+        await notify.user(
             row.requested_by,
             f"The CAP approval vote to {_describe_request(row)} passed. You can now complete this in ATR.",
             sql.NotificationLevel.INFO,
@@ -91,7 +76,7 @@ async def _apply_outcome(request_id: int, row: sql.ApprovalRequest, resolution: 
         )
         return
     if await _record_outcome(request_id, sql.ApprovalStatus.REJECTED, vote_outcome, permalink):
-        await notify(
+        await notify.user(
             row.requested_by,
             f"The CAP approval vote to {_describe_request(row)} did not pass (outcome: {vote_outcome}).",
             sql.NotificationLevel.WARNING,
@@ -121,7 +106,7 @@ async def _complete_release_archival(row: sql.ApprovalRequest) -> None:
                 await wacrs.project_record_approval_failure(row.id, error)
         except Exception:
             log.exception(f"Could not mark CAP request {row.id} as failed")
-        await notify(
+        await notify.user(
             row.requested_by,
             f"The CAP approval vote to {_describe_request(row)} passed, but ATR could not archive the"
             f" release automatically: {error}.",
@@ -130,7 +115,7 @@ async def _complete_release_archival(row: sql.ApprovalRequest) -> None:
         return
 
     # Same confirmation the by-hand completion posts
-    await notify(
+    await notify.user(
         row.requested_by,
         f"Release {project_key} {release_version} was archived after CAP approval.",
         sql.NotificationLevel.INFO,
@@ -171,7 +156,7 @@ async def _reschedule_or_fail(task_args: args.CapApprovalResolveArgs, row: sql.A
     attempts = len(constants.CAP_RESOLVE_RETRY_DELAYS) + 1
     error = f"CAP could not be resolved after {attempts} attempts"
     if await _record_outcome(task_args.approval_request_id, sql.ApprovalStatus.FAILED, None, None, error=error):
-        await notify(
+        await notify.user(
             row.requested_by,
             f"ATR could not resolve the CAP approval vote to {_describe_request(row)}: {error}.",
             sql.NotificationLevel.ERROR,

--- a/atr/tasks/svnpub.py
+++ b/atr/tasks/svnpub.py
@@ -17,8 +17,13 @@
 
 import atr.models.args as args
 import atr.models.results as results
+import atr.models.sql as sql
+import atr.notify as notify
 import atr.storage as storage
+import atr.storage.datatypes as datatypes
 import atr.tasks.checks as checks
+import atr.tasks.task as task
+import atr.util as util
 
 
 @checks.with_model(args.ReleaseFinalise)
@@ -32,3 +37,37 @@ async def publish(task_args: args.SvnPublish) -> results.Results | None:
     async with storage.write(task_args.asf_uid) as write:
         warm = await write.as_project_release_manager(task_args.project_key)
         return await warm.release.publish_to_svn_execute(task_args)
+
+
+@checks.with_model(args.SvnUnpublish)
+async def unpublish(task_args: args.SvnUnpublish) -> results.Results | None:
+    try:
+        async with storage.write_as_system(storage.WriteAsReleaseUnpublishService) as waru:
+            result = await waru.release_unpublish_from_svn(task_args)
+    except datatypes.RetryableError as exc:
+        # A transient SVN failure - a concurrent commit moved the tree, or a connection wobble.
+        # Send the task back to the queue; a later run re-reads the head and usually settles.
+        raise task.DeferredError(str(exc)) from exc
+    except datatypes.FailedError:
+        # The removal failed for good, so the release is archived in the record but its files
+        # are still in dist. Put it back to current so the two agree, and tell the archiver.
+        async with storage.write_as_system(storage.WriteAsReleaseUnpublishService) as waru:
+            await waru.revert_failed_archive(task_args.project_key, task_args.version_key)
+        message = (
+            f"Could not archive {task_args.project_key!s}-{task_args.version_key!s}: its files could not be"
+            " removed from the distribution area, you may wish to retry archiving this release."
+        )
+        await notify.user(task_args.asf_uid, message, sql.NotificationLevel.WARNING)
+        raise
+    if result.leftover:
+        # Tell whoever archived it that these files may need a manual tidy-up.
+        shown = ", ".join(result.leftover[:2])
+        if len(result.leftover) > 2:
+            shown += f" and {len(result.leftover) - 2} more"
+        message = (
+            f"Archived {task_args.project_key!s}-{task_args.version_key!s}, but "
+            f"{util.plural(len(result.leftover), 'file')} may need manual cleanup in the "
+            f"distribution area: {shown}"
+        )
+        await notify.user(task_args.asf_uid, message, sql.NotificationLevel.WARNING)
+    return result

--- a/migrations/versions/0124_2026.09.02_b7e2f1a9.py
+++ b/migrations/versions/0124_2026.09.02_b7e2f1a9.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Release archive source
+
+Revision ID: 0124_2026.09.02_b7e2f1a9
+Revises: 0123_2026.08.27_853c7eed
+Create Date: 2026-09-02 14:23:07.482915+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "0124_2026.09.02_b7e2f1a9"
+down_revision: str | None = "0123_2026.08.27_853c7eed"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # SQLModel persists enums by member name, so the column holds MANUAL/CAP/... not values.
+    # Nullable: releases archived before this was tracked keep a null source.
+    with op.batch_alter_table("release", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "archive_source",
+                sa.Enum("MANUAL", "CAP", "AUTO_PRIOR", "DIST_WATCHER", "CATALOG_ADMIN", name="archivesource"),
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("release", schema=None) as batch_op:
+        batch_op.drop_column("archive_source")

--- a/tests/unit/test_announce_auto_archive.py
+++ b/tests/unit/test_announce_auto_archive.py
@@ -20,9 +20,12 @@ from types import SimpleNamespace
 
 import pytest
 
+import atr.config as config
 import atr.models.safe as safe
+import atr.models.sql as sql
 import atr.storage as storage
 import atr.storage.writers.announce as announce
+import atr.storage.writers.release as release_writer
 
 
 def announced_release(*, release_opt_in: bool = True, policy_opt_in: bool = True) -> SimpleNamespace:
@@ -105,6 +108,41 @@ async def test_auto_archive_reports_archive_failure(monkeypatch: pytest.MonkeyPa
 
     with pytest.raises(storage.AccessError, match="Release announced, but archiving prior release"):
         await release_manager._ReleaseManager__archive_prior_release(announced_release(), True)
+
+
+@pytest.mark.asyncio
+async def test_auto_archive_enqueues_svn_unpublish_for_prior(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Archiving the prior release must remove it from dist, same as any archive
+    publish_url = "https://internal.example.invalid/repos/dist/release"
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", publish_url, raising=False)
+    monkeypatch.setattr(release_writer.catalog_site, "queue_regeneration", mock.AsyncMock())
+    prior = SimpleNamespace(
+        key="example-1.0.0",
+        phase=sql.ReleasePhase.RELEASE,
+        project_key="example",
+        version="1.0.0",
+        cycle_key="example-default",
+        download_path_suffix="example/1.0.0",
+    )
+    release_manager = writer()
+    mock_data = release_manager._ReleaseManager__data
+    update_result = mock.MagicMock()
+    update_result.rowcount = 1
+    mock_data.execute_query = mock.AsyncMock(return_value=update_result)
+    mock_data.add = mock.MagicMock()
+    mock_data.commit = mock.AsyncMock()
+
+    error = await release_manager._ReleaseManager__archive_release(
+        safe.ProjectKey("example"), safe.VersionKey("1.0.0"), prior
+    )
+
+    assert error is None
+    tasks = [
+        call.args[0]
+        for call in mock_data.add.call_args_list
+        if isinstance(call.args[0], sql.Task) and call.args[0].task_type is sql.TaskType.SVN_UNPUBLISH
+    ]
+    assert len(tasks) == 1
 
 
 def writer() -> announce.ReleaseManager:

--- a/tests/unit/test_catalogue_writer.py
+++ b/tests/unit/test_catalogue_writer.py
@@ -26,6 +26,7 @@ import sqlalchemy.ext.asyncio
 import sqlalchemy.pool
 import sqlmodel
 
+import atr.config as config
 import atr.db as db
 import atr.models.safe as safe
 import atr.models.sql as sql
@@ -337,20 +338,6 @@ async def test_archive_release_marks_it_archived(sessionmaker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_restore_release_returns_it_to_current(sessionmaker) -> None:
-    async with sessionmaker() as data:
-        await _seed_project(data, "alpha", "alpha-one")
-        await _seed_release_with_children(data, "alpha-one", "1.0.0")
-        await _writer(data).archive_release(safe.ReleaseKey("alpha-one-1.0.0"))
-
-        await _writer(data).restore_release(safe.ReleaseKey("alpha-one-1.0.0"))
-
-        release = await data.get(sql.Release, "alpha-one-1.0.0")
-        assert release is not None
-        assert release.is_archived is False
-
-
-@pytest.mark.asyncio
 async def test_archive_release_rejects_one_already_in_that_status(sessionmaker) -> None:
     async with sessionmaker() as data:
         await _seed_project(data, "alpha", "alpha-one")
@@ -369,6 +356,85 @@ async def test_restore_release_rejects_one_already_in_that_status(sessionmaker) 
 
         with pytest.raises(storage.AccessError, match="already"):
             await _writer(data).restore_release(safe.ReleaseKey("alpha-one-1.0.0"))
+
+
+@pytest.mark.asyncio
+async def test_archive_release_records_the_catalogue_admin_source(sessionmaker) -> None:
+    async with sessionmaker() as data:
+        await _seed_project(data, "alpha", "alpha-one")
+        await _seed_release_with_children(data, "alpha-one", "1.0.0")
+
+        await _writer(data).archive_release(safe.ReleaseKey("alpha-one-1.0.0"))
+
+        release = await data.get(sql.Release, "alpha-one-1.0.0")
+        assert release is not None
+        assert release.archive_source is sql.ArchiveSource.CATALOG_ADMIN
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        sql.ArchiveSource.MANUAL,
+        sql.ArchiveSource.CAP,
+        sql.ArchiveSource.AUTO_PRIOR,
+        sql.ArchiveSource.DIST_WATCHER,
+        sql.ArchiveSource.CATALOG_ADMIN,
+    ],
+)
+@pytest.mark.asyncio
+async def test_restore_release_refuses_an_archival_whose_files_left_dist(sessionmaker, source) -> None:
+    # Every tracked source - by hand, CAP, auto, the dist watcher, or a catalogue archive -
+    # took the files out of dist, so the catalogue must not offer the release back to current.
+    async with sessionmaker() as data:
+        await _seed_project(data, "alpha", "alpha-one")
+        await _seed_release_with_children(data, "alpha-one", "1.0.0")
+        release = await data.get(sql.Release, "alpha-one-1.0.0")
+        assert release is not None
+        release.is_archived = True
+        release.archive_source = source
+        await data.commit()
+
+        with pytest.raises(storage.AccessError, match="distribution area"):
+            await _writer(data).restore_release(safe.ReleaseKey("alpha-one-1.0.0"))
+
+
+@pytest.mark.asyncio
+async def test_restore_release_allows_a_legacy_untracked_archival(sessionmaker) -> None:
+    # A release archived before the source was tracked (null source) is treated as a
+    # catalogue-metadata archive, so it can still be restored.
+    async with sessionmaker() as data:
+        await _seed_project(data, "alpha", "alpha-one")
+        await _seed_release_with_children(data, "alpha-one", "1.0.0")
+        release = await data.get(sql.Release, "alpha-one-1.0.0")
+        assert release is not None
+        release.is_archived = True
+        release.archive_source = None
+        await data.commit()
+
+        await _writer(data).restore_release(safe.ReleaseKey("alpha-one-1.0.0"))
+
+        release = await data.get(sql.Release, "alpha-one-1.0.0")
+        assert release is not None
+        assert release.is_archived is False
+
+
+@pytest.mark.asyncio
+async def test_archive_release_removes_files_from_dist(sessionmaker, monkeypatch) -> None:
+    # A catalogue archive acts on a current release, whose files are live in dist, so it
+    # queues a removal to take them out.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", "https://svn.example.invalid/dist", raising=False)
+    async with sessionmaker() as data:
+        await _seed_project(data, "alpha", "alpha-one")
+        await _seed_release_with_children(data, "alpha-one", "1.0.0")
+        release = await data.get(sql.Release, "alpha-one-1.0.0")
+        assert release is not None
+        release.download_path_suffix = "alpha-one/1.0.0"
+        await data.commit()
+
+        await _writer(data).archive_release(safe.ReleaseKey("alpha-one-1.0.0"))
+
+        tasks = (await data.execute(sqlmodel.select(sql.Task))).scalars().all()
+        assert len([t for t in tasks if t.task_type is sql.TaskType.SVN_UNPUBLISH]) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_release_archive_approval.py
+++ b/tests/unit/test_release_archive_approval.py
@@ -78,6 +78,23 @@ async def test_complete_archive_claims_and_archives_in_one_transaction() -> None
 
 
 @pytest.mark.asyncio
+async def test_complete_archive_attributes_the_archival_to_the_requester() -> None:
+    # The SVN removal must commit under a real ASF UID, so the archival is attributed to the
+    # committer who requested the vote, not the system running the resolve task.
+    approval = _approval()
+    data = _data(approval=approval)
+    write = mock.MagicMock()
+    write.authorisation.asf_uid = "tester"
+    write_as = mock.MagicMock()
+    writer = release_writer.FoundationAdmin(write, write_as, data)
+
+    await writer.complete_archive(safe.ProjectKey("alpha-one"), safe.VersionKey("1.2.0"), 7)
+
+    write_as.append_to_audit_log.assert_called_once()
+    assert write_as.append_to_audit_log.call_args.kwargs["asf_uid"] == "requester"
+
+
+@pytest.mark.asyncio
 async def test_complete_archive_takes_the_write_lock_before_reading_the_approval() -> None:
     # Without the lock two completions could both read the approval as approved
     approval = _approval(status=sql.ApprovalStatus.PENDING)
@@ -120,6 +137,7 @@ def _approval(
         project_key="alpha-one",
         committee_key="alpha",
         release_version=release_version,
+        requested_by="requester",
     )
 
 

--- a/tests/unit/test_release_writer_archive.py
+++ b/tests/unit/test_release_writer_archive.py
@@ -21,10 +21,13 @@ from types import SimpleNamespace
 
 import pytest
 
+import atr.config as config
 import atr.models.safe as safe
 import atr.models.sql as sql
 import atr.storage as storage
 import atr.storage.writers.release as release
+
+_PUBLISH_URL = "https://internal.example.invalid/repos/dist/release"
 
 
 class ReleaseQuery:
@@ -129,10 +132,121 @@ async def test_archive_succeeds_and_writes_lifecycle_event():
     assert mock_data.commit.await_count == 1
 
 
+@pytest.mark.asyncio
+async def test_archive_enqueues_svn_unpublish_when_published(monkeypatch):
+    # Archiving a release that ATR published should queue its removal from dist
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", _PUBLISH_URL, raising=False)
+    target = _archive_candidate(version="1.0.0", download_path_suffix="example/1.0.0")
+    member = _make_member(release_result=target, siblings=[_archive_candidate(version="2.0.0")])
+    mock_data = member._CommitteeMember__data  # type: ignore[attr-defined]
+    update_result = mock.MagicMock()
+    update_result.rowcount = 1
+    mock_data.execute_query = mock.AsyncMock(return_value=update_result)
+
+    await member.archive(safe.ProjectKey("example"), safe.VersionKey("1.0.0"))
+
+    added_args = [call.args[0] for call in mock_data.add.call_args_list]
+    tasks = [a for a in added_args if isinstance(a, sql.Task) and a.task_type is sql.TaskType.SVN_UNPUBLISH]
+    assert len(tasks) == 1
+    task = tasks[0]
+    assert task.project_key == "example"
+    assert task.version_key == "1.0.0"
+    # The task only names the release; the executor resolves where the files went
+    assert "download_path_suffix" not in task.task_args
+
+
+@pytest.mark.asyncio
+async def test_archive_enqueues_svn_unpublish_for_a_root_published_release(monkeypatch):
+    # An empty suffix means the release lives at the committee dist root; it must still be removed
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", _PUBLISH_URL, raising=False)
+    target = _archive_candidate(version="1.0.0", download_path_suffix="")
+    member = _make_member(release_result=target, siblings=[_archive_candidate(version="2.0.0")])
+    mock_data = member._CommitteeMember__data  # type: ignore[attr-defined]
+    update_result = mock.MagicMock()
+    update_result.rowcount = 1
+    mock_data.execute_query = mock.AsyncMock(return_value=update_result)
+
+    await member.archive(safe.ProjectKey("example"), safe.VersionKey("1.0.0"))
+
+    added_args = [call.args[0] for call in mock_data.add.call_args_list]
+    tasks = [a for a in added_args if isinstance(a, sql.Task) and a.task_type is sql.TaskType.SVN_UNPUBLISH]
+    assert len(tasks) == 1
+    assert tasks[0].version_key == "1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_archive_queues_svn_unpublish_without_a_suffix(monkeypatch):
+    # A catalogued release carries no release-level suffix but its artifacts still record
+    # dist locations, so a removal is queued and the executor works out what to take out.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", _PUBLISH_URL, raising=False)
+    target = _archive_candidate(version="1.0.0", download_path_suffix=None)
+    member = _make_member(release_result=target, siblings=[_archive_candidate(version="2.0.0")])
+    mock_data = member._CommitteeMember__data  # type: ignore[attr-defined]
+    update_result = mock.MagicMock()
+    update_result.rowcount = 1
+    mock_data.execute_query = mock.AsyncMock(return_value=update_result)
+
+    await member.archive(safe.ProjectKey("example"), safe.VersionKey("1.0.0"))
+
+    added_args = [call.args[0] for call in mock_data.add.call_args_list]
+    tasks = [a for a in added_args if isinstance(a, sql.Task) and a.task_type is sql.TaskType.SVN_UNPUBLISH]
+    assert len(tasks) == 1
+    assert tasks[0].version_key == "1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_archive_skips_svn_unpublish_when_svn_not_configured(monkeypatch):
+    # Without an SVN publish target there is nothing to remove, so no task
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", None, raising=False)
+    target = _archive_candidate(version="1.0.0", download_path_suffix="example/1.0.0")
+    member = _make_member(release_result=target, siblings=[_archive_candidate(version="2.0.0")])
+    mock_data = member._CommitteeMember__data  # type: ignore[attr-defined]
+    update_result = mock.MagicMock()
+    update_result.rowcount = 1
+    mock_data.execute_query = mock.AsyncMock(return_value=update_result)
+
+    await member.archive(safe.ProjectKey("example"), safe.VersionKey("1.0.0"))
+
+    added_args = [call.args[0] for call in mock_data.add.call_args_list]
+    tasks = [a for a in added_args if isinstance(a, sql.Task) and a.task_type is sql.TaskType.SVN_UNPUBLISH]
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_archive_core_skips_svn_unpublish_for_a_dist_watcher_archival(monkeypatch):
+    # The dist watcher archives a release because its files already left dist, so
+    # there is nothing to remove and no task to enqueue
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", _PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release.catalog_site, "queue_regeneration", mock.AsyncMock())
+    target = _archive_candidate(version="1.0.0", download_path_suffix="example/1.0.0")
+    mock_data = mock.MagicMock()
+    update_result = mock.MagicMock()
+    update_result.rowcount = 1
+    mock_data.execute_query = mock.AsyncMock(return_value=update_result)
+    mock_data.add = mock.MagicMock()
+    mock_data.commit = mock.AsyncMock()
+
+    error = await release.archive_release_core(
+        mock_data,
+        mock.MagicMock(),
+        "alice",
+        safe.ProjectKey("example"),
+        safe.VersionKey("1.0.0"),
+        target,
+        sql.ArchiveSource.DIST_WATCHER,
+    )
+
+    assert error is None
+    added_args = [call.args[0] for call in mock_data.add.call_args_list]
+    tasks = [a for a in added_args if isinstance(a, sql.Task) and a.task_type is sql.TaskType.SVN_UNPUBLISH]
+    assert tasks == []
+
+
 def _archive_candidate(
     version: str = "1.0.0",
     phase: sql.ReleasePhase = sql.ReleasePhase.RELEASE,
     is_archived: bool = False,
+    download_path_suffix: str | None = "",
 ) -> SimpleNamespace:
     return SimpleNamespace(
         key=f"example-{version}",
@@ -143,6 +257,7 @@ def _archive_candidate(
         released=datetime.datetime(2026, 1, int(version[0]) or 1, tzinfo=datetime.UTC),
         project_key="example",
         cycle_key="example-default",
+        download_path_suffix=download_path_suffix,
     )
 
 

--- a/tests/unit/test_svn_errors.py
+++ b/tests/unit/test_svn_errors.py
@@ -54,6 +54,14 @@ def test_error_message_reports_timeout() -> None:
     assert "see https://status.apache.org/" in message
 
 
+def test_parse_svnmucc_revision_reads_the_svnmucc_commit_line() -> None:
+    # svnmucc reports a commit in its own format, not svn's "Committed revision N.",
+    # so the removal path must parse this shape or it never records a revision.
+    assert svn.parse_svnmucc_revision("r4231 committed by asftool at 2026-09-02T14:23:07.482Z") == 4231
+    assert svn.parse_svnmucc_revision("Committed revision 4231.") is None
+    assert svn.parse_svnmucc_revision("no revision line here") is None
+
+
 def test_error_message_uses_specific_stacked_error() -> None:
     exc = svn.CommandExecutionError(
         1,
@@ -272,3 +280,61 @@ def _svn_info(root: str = "https://dist.apache.org/repos/dist/atr") -> svn.SvnIn
         last_changed_rev="42",
         last_changed_date="2026-05-01 00:00:00 +0000",
     )
+
+
+def test_path_missing_error_recognises_svn_info_not_found() -> None:
+    # Real svn 1.14 stderr for `svn info` on a missing URL (file:// and https)
+    exc = svn.CommandExecutionError(
+        1,
+        "svn: warning: W170000: URL 'https://svn/x' non-existent in revision 87117\n"
+        "svn: E200009: Could not display info for all targets because some targets don't exist",
+    )
+    assert svn.path_missing_error(exc) is True
+
+
+def test_path_missing_error_recognises_svn_list_not_found() -> None:
+    # Real svn 1.14 stderr for `svn list` on a missing directory
+    exc = svn.CommandExecutionError(
+        1,
+        "svn: warning: W160013: Path '/missing/dir' not found\n"
+        "svn: E200009: Could not list all targets because some targets don't exist",
+    )
+    assert svn.path_missing_error(exc) is True
+
+
+def test_path_missing_error_recognises_svn_delete_not_found() -> None:
+    # Real svn 1.14 stderr for `svn delete` on a missing URL
+    exc = svn.CommandExecutionError(1, "svn: E160013: URL 'https://svn/gone' does not exist")
+    assert svn.path_missing_error(exc) is True
+
+
+def test_path_missing_error_rejects_a_connection_error() -> None:
+    exc = svn.CommandExecutionError(1, "svn: E170013: Unable to connect to a repository at URL 'https://svn'")
+    assert svn.path_missing_error(exc) is False
+
+
+def test_path_missing_error_rejects_a_timeout() -> None:
+    assert svn.path_missing_error(svn.CommandTimeoutError(30.0)) is False
+
+
+def test_path_missing_error_rejects_an_auth_failure() -> None:
+    exc = svn.CommandExecutionError(1, "svn: E215004: Authentication failed")
+    assert svn.path_missing_error(exc) is False
+
+
+def test_retryable_error_recognises_an_out_of_date_baseline() -> None:
+    # A concurrent commit moved a targeted path since we listed it; a retry re-reads head
+    for code in ("E160028", "E170004"):
+        exc = svn.CommandExecutionError(1, f"svn: {code}: Item is out of date; try updating")
+        assert svn.retryable_error(exc) is True
+
+
+def test_retryable_error_recognises_a_connection_error() -> None:
+    exc = svn.CommandExecutionError(1, "svn: E170013: Unable to connect to a repository at URL 'https://svn'")
+    assert svn.retryable_error(exc) is True
+
+
+def test_retryable_error_rejects_a_terminal_failure() -> None:
+    # A missing path or an auth failure won't clear on a retry, so they stay terminal
+    assert svn.retryable_error(svn.CommandExecutionError(1, "svn: E160013: URL does not exist")) is False
+    assert svn.retryable_error(svn.CommandExecutionError(1, "svn: E215004: Authentication failed")) is False

--- a/tests/unit/test_svn_unpublish_writer.py
+++ b/tests/unit/test_svn_unpublish_writer.py
@@ -1,0 +1,623 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import unittest.mock as mock
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Final
+
+import pytest
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+import sqlmodel
+
+import atr.config as config
+import atr.db as db
+import atr.models.args as args
+import atr.models.results as results
+import atr.models.safe as safe
+import atr.models.sql as sql
+import atr.storage.datatypes as datatypes
+import atr.storage.writers.release as release_writer
+
+INTERNAL_PUBLISH_URL: Final[str] = "https://internal.example.invalid/repos/dist/release"
+# The release lives under the committee dir "project" plus its "1.0.0" suffix.
+DIST_DIR: Final[str] = "project/1.0.0"
+ARTIFACT: Final[str] = "apache-project-1.0.0.tar.gz"
+SIGNATURE: Final[str] = "apache-project-1.0.0.tar.gz.asc"
+CHECKSUM: Final[str] = "apache-project-1.0.0.tar.gz.sha512"
+SBOM: Final[str] = "apache-project-1.0.0.tar.gz.cdx.json"
+ALL_FILES: Final[list[str]] = [ARTIFACT, SIGNATURE, CHECKSUM, SBOM]
+# svn 1.14 stderr for a listing of a missing directory, over file:// and https.
+MISSING_DIR_OUTPUT: Final[str] = (
+    "svn: warning: W170000: URL 'https://svn/x' non-existent in revision 87117\n"
+    "svn: E200009: Could not display info for all targets because some targets don't exist"
+)
+# The dist area head the removal pins itself to, held steady across tests.
+BASE_REVISION: Final[int] = 87116
+
+
+@pytest.fixture
+async def sqlite_sessionmaker() -> AsyncIterator[sqlalchemy.ext.asyncio.async_sessionmaker[db.Session]]:
+    engine = sqlalchemy.ext.asyncio.create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(sqlmodel.SQLModel.metadata.create_all)
+    sessionmaker = sqlalchemy.ext.asyncio.async_sessionmaker(bind=engine, class_=db.Session, expire_on_commit=False)
+    yield sessionmaker
+    await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _pinned_base_revision(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The unpublish reads the dist area's head to pin its removal against. Give every test a
+    # settled revision, so the writer never reaches for a real svn info. A test that wants the
+    # root itself gone re-patches from_url to raise.
+    monkeypatch.setattr(
+        release_writer.svn.SvnInfo,
+        "from_url",
+        mock.AsyncMock(return_value=SimpleNamespace(revision_number=BASE_REVISION)),
+    )
+
+
+def _args() -> args.SvnUnpublish:
+    return args.SvnUnpublish(asf_uid="alice", project_key="project", version_key="1.0.0")
+
+
+async def test_unpublish_takes_an_owned_directory_whole(sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The directory holds nothing but this release's files, so it comes out in one
+    # action - its files and the emptied directory together - not file by file.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=ALL_FILES))
+    # svnmucc reports the commit in its own format, not svn's "Committed revision N."
+    remove_files = mock.AsyncMock(return_value="r7 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert isinstance(result, results.SvnUnpublish)
+        assert result.svn_revision == 7
+        remove_files.assert_awaited_once()
+        base_url, rel_paths = remove_files.await_args.args[0], remove_files.await_args.args[1]
+        assert base_url == INTERNAL_PUBLISH_URL
+        assert rel_paths == [DIST_DIR]
+
+
+async def test_unpublish_never_removes_the_directory_itself(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A flat layout may hold other releases' files alongside ours, so removal is
+    # by explicit file - the bare directory must never be a removal target.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    listed = [*ALL_FILES, "other-2.0.0.tar.gz"]
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=listed))
+    remove_files = mock.AsyncMock(return_value="r8 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        rel_paths = remove_files.await_args.args[1]
+        assert DIST_DIR not in rel_paths
+        assert f"{DIST_DIR}/other-2.0.0.tar.gz" not in rel_paths
+        assert rel_paths == sorted(f"{DIST_DIR}/{name}" for name in ALL_FILES)
+
+
+async def test_unpublish_in_a_shared_directory_skips_a_file_already_gone(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A foreign file keeps the directory in place, so removal is by file; a recorded
+    # file that has already gone is left out rather than fail the atomic svnmucc commit.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    present = [ARTIFACT, CHECKSUM, SBOM, "other-2.0.0.tar.gz"]
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=present))
+    remove_files = mock.AsyncMock(return_value="r9 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        rel_paths = remove_files.await_args.args[1]
+        assert rel_paths == sorted(f"{DIST_DIR}/{name}" for name in (ARTIFACT, CHECKSUM, SBOM))
+        assert f"{DIST_DIR}/{SIGNATURE}" not in rel_paths
+        assert f"{DIST_DIR}/other-2.0.0.tar.gz" not in rel_paths
+
+
+async def test_unpublish_takes_an_owned_directory_with_a_subdirectory_whole(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The release put its files in a subdirectory of its own and the directory holds
+    # nothing else, so the whole directory - the subdirectory and its files - comes out
+    # in one action, leaving no empty directory behind.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(
+        release_writer.svn, "list_files", mock.AsyncMock(return_value=[f"binaries/{name}" for name in ALL_FILES])
+    )
+    remove_files = mock.AsyncMock(return_value="r11 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data, subdir="binaries")
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        rel_paths = remove_files.await_args.args[1]
+        assert rel_paths == [DIST_DIR]
+
+
+async def test_unpublish_keeps_a_subdirectory_shared_with_another_release(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A foreign file shares the subdirectory, so the directory must stay: only our
+    # own files come out, one by one, and the directory is never a removal target.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    listed = [*[f"binaries/{name}" for name in ALL_FILES], "binaries/other-2.0.0.tar.gz"]
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=listed))
+    remove_files = mock.AsyncMock(return_value="r12 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data, subdir="binaries")
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        rel_paths = remove_files.await_args.args[1]
+        assert f"{DIST_DIR}/binaries" not in rel_paths
+        assert f"{DIST_DIR}/binaries/other-2.0.0.tar.gz" not in rel_paths
+        assert rel_paths == sorted(f"{DIST_DIR}/binaries/{name}" for name in ALL_FILES)
+
+
+async def test_unpublish_skips_a_directory_that_lists_as_empty(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A directory that lists as empty must never become a removal target: svnmucc is
+    # atomic, so an rm of a path that isn't there would fail the whole commit.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=[]))
+    remove_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data, subdir="binaries")
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.svn_revision is None
+        remove_files.assert_not_awaited()
+
+
+async def test_unpublish_removes_manifest_files_including_a_readme(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The attestable manifest lists every file the bundle published, so a README that is
+    # not a recorded artifact is still removed. A foreign file keeps the directory, so the
+    # removal is by file and the README is an explicit target.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    manifest = SimpleNamespace(paths={name: None for name in (*ALL_FILES, "README")})
+    monkeypatch.setattr(release_writer.attestable, "latest_revision_number", mock.AsyncMock(return_value="00001"))
+    monkeypatch.setattr(release_writer.attestable, "load", mock.AsyncMock(return_value=manifest))
+    listed = [*ALL_FILES, "README", "other-2.0.0.tar.gz"]
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=listed))
+    remove_files = mock.AsyncMock(return_value="r13 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        rel_paths = remove_files.await_args.args[1]
+        assert f"{DIST_DIR}/README" in rel_paths
+        assert f"{DIST_DIR}/other-2.0.0.tar.gz" not in rel_paths
+        assert rel_paths == sorted(f"{DIST_DIR}/{name}" for name in (*ALL_FILES, "README"))
+
+
+async def test_unpublish_at_the_committee_root_removes_a_nested_file(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A prefix-less publish puts the release straight in the committee root. One recursive
+    # listing finds a file the release put in a subdirectory there, while the shared root -
+    # which also holds KEYS and other releases - is never taken.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    manifest = SimpleNamespace(
+        paths={"apache-project-1.0.0.tar.gz": None, "binaries/apache-project-1.0.0-bin.zip": None}
+    )
+    monkeypatch.setattr(release_writer.attestable, "latest_revision_number", mock.AsyncMock(return_value="00001"))
+    monkeypatch.setattr(release_writer.attestable, "load", mock.AsyncMock(return_value=manifest))
+    listed = ["apache-project-1.0.0.tar.gz", "binaries/apache-project-1.0.0-bin.zip", "KEYS", "9.9.9/other.tar.gz"]
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=listed))
+    remove_files = mock.AsyncMock(return_value="r14 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        # An empty release suffix is the deliberate committee root; the artifact sits there too
+        await _seed_release_with_artifacts(data, directory="project", release_suffix="")
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        rel_paths = remove_files.await_args.args[1]
+        assert "project/binaries/apache-project-1.0.0-bin.zip" in rel_paths
+        assert "project" not in rel_paths
+        assert "project/KEYS" not in rel_paths
+        assert "project/9.9.9/other.tar.gz" not in rel_paths
+        assert rel_paths == sorted(
+            ("project/apache-project-1.0.0.tar.gz", "project/binaries/apache-project-1.0.0-bin.zip")
+        )
+
+
+async def test_unpublish_reports_leftover_files_for_a_fallback_removal(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A catalogued release has no manifest, so removal falls back to the recorded artifacts,
+    # which can't account for a README. It is left behind and reported for manual cleanup.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.attestable, "latest_revision_number", mock.AsyncMock(return_value=None))
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=[*ALL_FILES, "README.md"]))
+    remove_files = mock.AsyncMock(return_value="r15 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.leftover == [f"{DIST_DIR}/README.md"]
+        assert remove_files.await_args.args[1] == sorted(f"{DIST_DIR}/{name}" for name in ALL_FILES)
+
+
+async def test_unpublish_does_not_report_leftovers_for_a_manifest_removal(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A manifest removal is complete, so anything else in a shared directory belongs to another
+    # release, not to us - it must not be reported as our leftover.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    manifest = SimpleNamespace(paths={name: None for name in ALL_FILES})
+    monkeypatch.setattr(release_writer.attestable, "latest_revision_number", mock.AsyncMock(return_value="00001"))
+    monkeypatch.setattr(release_writer.attestable, "load", mock.AsyncMock(return_value=manifest))
+    monkeypatch.setattr(
+        release_writer.svn, "list_files", mock.AsyncMock(return_value=[*ALL_FILES, "other-2.0.0.tar.gz"])
+    )
+    monkeypatch.setattr(
+        release_writer.svn,
+        "remove_files",
+        mock.AsyncMock(return_value="r16 committed by alice at 2026-09-02T14:23:07Z"),
+    )
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.leftover == []
+
+
+async def test_unpublish_does_not_report_leftovers_at_the_committee_root(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A prefix-less release sits in the shared committee root, whose other entries (KEYS,
+    # sibling releases) are not ours - a fallback removal must not report them as leftovers.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.attestable, "latest_revision_number", mock.AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        release_writer.svn, "list_files", mock.AsyncMock(return_value=[*ALL_FILES, "KEYS", "other-9.9.9.tar.gz"])
+    )
+    monkeypatch.setattr(
+        release_writer.svn,
+        "remove_files",
+        mock.AsyncMock(return_value="r17 committed by alice at 2026-09-02T14:23:07Z"),
+    )
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data, directory="project")
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.leftover == []
+
+
+async def test_unpublish_does_not_report_leftovers_in_a_shared_category_directory(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Some projects drop every release into one flat directory (plugins/, providers/) that carries
+    # no version. Its other entries are sibling releases, not our leftovers, so a fallback removal
+    # takes only our files and reports nothing left behind.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.attestable, "latest_revision_number", mock.AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        release_writer.svn, "list_files", mock.AsyncMock(return_value=[*ALL_FILES, "other-plugin-2.0.0.tar.gz"])
+    )
+    remove_files = mock.AsyncMock(return_value="r18 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data, directory="project/plugins")
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.leftover == []
+        assert remove_files.await_args.args[1] == sorted(f"project/plugins/{name}" for name in ALL_FILES)
+
+
+async def test_unpublish_reports_absent_when_the_directory_is_gone(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    listing = mock.AsyncMock(side_effect=release_writer.svn.CommandExecutionError(1, MISSING_DIR_OUTPUT))
+    monkeypatch.setattr(release_writer.svn, "list_files", listing)
+    remove_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.svn_revision is None
+        remove_files.assert_not_awaited()
+
+
+async def test_unpublish_pins_the_listing_and_removal_to_one_revision(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Both the listing and the svnmucc rm carry the dist head, so a commit that lands between
+    # them fails out of date rather than deleting against a tree we never looked at.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    list_files = mock.AsyncMock(return_value=ALL_FILES)
+    monkeypatch.setattr(release_writer.svn, "list_files", list_files)
+    remove_files = mock.AsyncMock(return_value="r7 committed by alice at 2026-09-02T14:23:07Z")
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        await writer.unpublish_from_svn_execute(_args())
+
+        assert all(call.args[1] == BASE_REVISION for call in list_files.await_args_list)
+        assert remove_files.await_args.kwargs["base_revision"] == BASE_REVISION
+
+
+async def test_unpublish_reports_absent_when_the_dist_root_is_gone(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With the whole dist area gone there's nothing to pin to and nothing to remove, so we
+    # report it absent rather than failing the task.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(
+        release_writer.svn.SvnInfo,
+        "from_url",
+        mock.AsyncMock(side_effect=release_writer.svn.CommandExecutionError(1, MISSING_DIR_OUTPUT)),
+    )
+    list_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "list_files", list_files)
+    remove_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.svn_revision is None
+        list_files.assert_not_awaited()
+        remove_files.assert_not_awaited()
+
+
+async def test_unpublish_defers_on_a_transient_svn_error(sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A connection error is not proof the files are gone, so the removal is retryable rather
+    # than terminal - the task defers and tries again instead of failing outright.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    listing = mock.AsyncMock(
+        side_effect=release_writer.svn.CommandExecutionError(1, "svn: E170013: Unable to connect to a repository")
+    )
+    monkeypatch.setattr(release_writer.svn, "list_files", listing)
+    remove_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        with pytest.raises(datatypes.RetryableError):
+            await writer.unpublish_from_svn_execute(_args())
+        remove_files.assert_not_awaited()
+
+
+async def test_unpublish_defers_when_the_removal_is_out_of_date(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The dist tree moved between the listing and the rm, so svnmucc rejects it out of date.
+    # That's the retryable case the baseline pin exists to surface.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=ALL_FILES))
+    monkeypatch.setattr(
+        release_writer.svn,
+        "remove_files",
+        mock.AsyncMock(side_effect=release_writer.svn.CommandExecutionError(1, "svn: E160028: is out of date")),
+    )
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        with pytest.raises(datatypes.RetryableError):
+            await writer.unpublish_from_svn_execute(_args())
+
+
+async def test_unpublish_fails_terminally_on_a_non_retryable_removal(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=ALL_FILES))
+    monkeypatch.setattr(
+        release_writer.svn,
+        "remove_files",
+        mock.AsyncMock(side_effect=release_writer.svn.CommandExecutionError(1, "svn: E160020: target already exists")),
+    )
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        with pytest.raises(datatypes.FailedError):
+            await writer.unpublish_from_svn_execute(_args())
+
+
+async def test_revert_failed_archive_restores_and_retracts(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A terminal removal leaves the files in dist, so the revert puts the release back to
+    # current and retracts the archive event with a withdraw - never deleting the CLE row.
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        release = await data.get(sql.Release, "project-1.0.0")
+        release.archive_source = sql.ArchiveSource.MANUAL
+        archive_event = sql.LifecycleEvent(
+            project_key="project",
+            version_key="project-1.0.0",
+            event=sql.LifecycleEventType.ARCHIVE,
+            effective=datetime.datetime(2026, 6, 1, tzinfo=datetime.UTC),
+            published=datetime.datetime(2026, 6, 1, tzinfo=datetime.UTC),
+        )
+        data.add_all([release, archive_event])
+        await data.commit()
+        archive_event_id = archive_event.id
+        writer = _admin_writer(data)
+
+        await writer.revert_failed_archive(safe.ProjectKey("project"), safe.VersionKey("1.0.0"))
+
+        restored = await data.get(sql.Release, "project-1.0.0")
+        assert restored.is_archived is False
+        assert restored.archived is None
+        assert restored.archive_source is None
+        events = list((await data.execute(sqlmodel.select(sql.LifecycleEvent))).scalars().all())
+        # The archive row survives; a single withdraw points back at it
+        assert any(event.id == archive_event_id for event in events)
+        withdraws = [event for event in events if event.event is sql.LifecycleEventType.WITHDRAW]
+        assert len(withdraws) == 1
+        assert withdraws[0].target_event_id == archive_event_id
+
+
+async def test_unpublish_reports_when_no_files_are_recorded(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    list_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "list_files", list_files)
+    remove_files = mock.AsyncMock()
+    monkeypatch.setattr(release_writer.svn, "remove_files", remove_files)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data, with_artifact=False)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.svn_revision is None
+        list_files.assert_not_awaited()
+        remove_files.assert_not_awaited()
+
+
+async def test_unpublish_omits_the_revision_when_svn_reports_none(
+    sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", INTERNAL_PUBLISH_URL, raising=False)
+    monkeypatch.setattr(release_writer.svn, "list_files", mock.AsyncMock(return_value=ALL_FILES))
+    monkeypatch.setattr(release_writer.svn, "remove_files", mock.AsyncMock(return_value="done, no revision line"))
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        result = await writer.unpublish_from_svn_execute(_args())
+
+        assert result.svn_revision is None
+        assert "rNone" not in result.message
+
+
+async def test_unpublish_fails_when_svn_is_not_configured(sqlite_sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.get(), "SVN_PUBLISH_URL", None, raising=False)
+    async with sqlite_sessionmaker() as data:
+        await _seed_release_with_artifacts(data)
+        writer = _admin_writer(data)
+
+        with pytest.raises(datatypes.FailedError):
+            await writer.unpublish_from_svn_execute(_args())
+
+
+def _admin_writer(data: db.Session) -> release_writer.FoundationAdmin:
+    writer = object.__new__(release_writer.FoundationAdmin)
+    writer._FoundationAdmin__asf_uid = "alice"
+    writer._FoundationAdmin__data = data
+    writer._FoundationAdmin__write_as = SimpleNamespace(append_to_audit_log=mock.Mock())
+    writer._FoundationAdmin__write = mock.MagicMock()
+    return writer
+
+
+async def _seed_release_with_artifacts(
+    data: db.Session,
+    *,
+    with_artifact: bool = True,
+    subdir: str | None = None,
+    directory: str = DIST_DIR,
+    release_suffix: str = "1.0.0",
+) -> None:
+    committee = sql.Committee(
+        key="project",
+        name="Project",
+        is_podling=False,
+        committee_members=["alice"],
+        committers=["alice"],
+    )
+    project = sql.Project(key="project", name="Project", committee=committee)
+    release = sql.Release(
+        key="project-1.0.0",
+        phase=sql.ReleasePhase.RELEASE,
+        project=project,
+        project_key=project.key,
+        version="1.0.0",
+        created=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+        is_archived=True,
+        archived=datetime.datetime(2026, 6, 1, tzinfo=datetime.UTC),
+        download_path_suffix=release_suffix,
+    )
+    rows: list[object] = [committee, project, release]
+    if with_artifact:
+        # A subdir models a release that published into a subdirectory of its own,
+        # so the recorded file name carries that prefix while the directory stays the base.
+        prefix = f"{subdir}/" if subdir else ""
+        rows.append(
+            sql.Artifact(
+                project_key="project",
+                version="1.0.0",
+                artifact_path=f"{prefix}{ARTIFACT}",
+                signature_path=f"{prefix}{SIGNATURE}",
+                checksum_path=f"{prefix}{CHECKSUM}",
+                sbom_path=f"{prefix}{SBOM}",
+                release_key="project-1.0.0",
+                managed=True,
+                download_path_suffix=directory,
+            )
+        )
+    data.add_all(rows)
+    await data.commit()

--- a/tests/unit/test_svnpub_unpublish.py
+++ b/tests/unit/test_svnpub_unpublish.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import unittest.mock as mock
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+import atr.models.args as args
+import atr.models.results as results
+import atr.storage.datatypes as datatypes
+import atr.tasks.svnpub as svnpub
+import atr.tasks.task as task
+
+
+def _task_args() -> dict[str, Any]:
+    return args.SvnUnpublish(asf_uid="alice", project_key="project", version_key="1.0.0").model_dump()
+
+
+def _write_as_system(service: mock.Mock) -> Any:
+    @contextlib.asynccontextmanager
+    async def _cm(_service_cls: Any) -> AsyncIterator[mock.Mock]:
+        yield service
+
+    return _cm
+
+
+async def test_unpublish_defers_a_retryable_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = mock.Mock()
+    service.release_unpublish_from_svn = mock.AsyncMock(side_effect=datatypes.RetryableError("out of date"))
+    service.revert_failed_archive = mock.AsyncMock()
+    monkeypatch.setattr(svnpub.storage, "write_as_system", _write_as_system(service))
+    notify_user = mock.AsyncMock()
+    monkeypatch.setattr(svnpub.notify, "user", notify_user)
+
+    with pytest.raises(task.DeferredError):
+        await svnpub.unpublish(_task_args())
+
+    # A deferral leaves the archival alone and says nothing to the user - it will try again
+    service.revert_failed_archive.assert_not_awaited()
+    notify_user.assert_not_awaited()
+
+
+async def test_unpublish_reverts_and_notifies_on_a_terminal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = mock.Mock()
+    service.release_unpublish_from_svn = mock.AsyncMock(side_effect=datatypes.FailedError("gone for good"))
+    service.revert_failed_archive = mock.AsyncMock()
+    monkeypatch.setattr(svnpub.storage, "write_as_system", _write_as_system(service))
+    notify_user = mock.AsyncMock()
+    monkeypatch.setattr(svnpub.notify, "user", notify_user)
+
+    # The task still records a failure, but the release is put back and the archiver told
+    with pytest.raises(datatypes.FailedError):
+        await svnpub.unpublish(_task_args())
+
+    service.revert_failed_archive.assert_awaited_once()
+    notify_user.assert_awaited_once()
+
+
+async def test_unpublish_returns_the_result_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = results.SvnUnpublish(kind="svn_unpublish", svn_revision=7, message="done")
+    service = mock.Mock()
+    service.release_unpublish_from_svn = mock.AsyncMock(return_value=result)
+    service.revert_failed_archive = mock.AsyncMock()
+    monkeypatch.setattr(svnpub.storage, "write_as_system", _write_as_system(service))
+    notify_user = mock.AsyncMock()
+    monkeypatch.setattr(svnpub.notify, "user", notify_user)
+
+    assert await svnpub.unpublish(_task_args()) is result
+    service.revert_failed_archive.assert_not_awaited()
+    notify_user.assert_not_awaited()


### PR DESCRIPTION
Add SVN rm command on all archive paths EXCEPT those triggered from the SVN dist watcher (since it's detecting an rm itself) and those in the catalog admin page (where you're manipulating data which didn't flow through ATR (from an import script or the dist watcher) and whose files will therefore be managed by the dist watcher. If we want to allow ATR to remove SVN files for non-ATR releases that's a different process!