### PR TITLE
feat(util): automatically derive committee user mailing list names (#1567)

### DIFF
--- a/atr/util.py
+++ b/atr/util.py
@@ -183,6 +183,8 @@ USERS_LIST_COMMITTEES: Final[frozenset[str]] = frozenset(
     }
 )
 LISTS_APACHE_TIMEOUT: Final[aiohttp.ClientTimeout] = aiohttp.ClientTimeout(total=30, connect=10)
+LISTS_PREFERENCES_URL: Final[str] = "https://lists.apache.org/api/preferences.json"
+_MAILING_LISTS_CACHE: dict[str, frozenset[str]] | None = None
 CAP_TIMEOUT: Final[aiohttp.ClientTimeout] = aiohttp.ClientTimeout(total=30, connect=10)
 PROPAGATION_TIMEOUT: Final[aiohttp.ClientTimeout] = aiohttp.ClientTimeout(total=10, connect=5)
 PROPAGATION_PROBE_DEADLINE: Final[int] = 15
@@ -645,12 +647,45 @@ def concern_groups(info: "datatypes.PathInfo | None") -> list[ConcernGroup]:
     ]
 
 
+def committee_user_list_name(committee_key: str) -> str:
+    """Derive whether a committee uses 'users' or 'user' as its public user list name."""
+    if _MAILING_LISTS_CACHE is not None:
+        domain = f"{committee_key}.apache.org"
+        lists = _MAILING_LISTS_CACHE.get(domain)
+        if lists is not None:
+            if "users" in lists:
+                return "users"
+            if "user" in lists:
+                return "user"
+    return "users" if (committee_key in USERS_LIST_COMMITTEES) else "user"
+
+
+async def fetch_apache_mailing_lists() -> dict[str, frozenset[str]]:
+    """Fetch the mapping of Apache domain names to available mailing lists from lists.apache.org."""
+    global _MAILING_LISTS_CACHE
+    async with create_secure_session(timeout=LISTS_APACHE_TIMEOUT, ipv4_only=True) as session:
+        async with session.get(LISTS_PREFERENCES_URL) as response:
+            response.raise_for_status()
+            data: Any = await response.json(content_type=None)
+
+    cache: dict[str, frozenset[str]] = {}
+    if isinstance(data, dict):
+        lists_data = data.get("lists")
+        if isinstance(lists_data, dict):
+            for domain, domain_lists in lists_data.items():
+                if isinstance(domain, str) and isinstance(domain_lists, dict):
+                    cache[domain] = frozenset(str(name) for name in domain_lists)
+
+    _MAILING_LISTS_CACHE = cache
+    return cache
+
+
 def configurable_recipients(action: sql.RecipientAction, committee_key: str, *, is_podling: bool) -> list[str]:
     # Stable, committee-derived recipients a project can persist as defaults.
     # These don't depend on the sender or on ALPHA test addresses, so a stored
     # default stays valid for whoever later sends the email.
     if action == sql.RecipientAction.ANNOUNCE:
-        user_list_name = "users" if (committee_key in USERS_LIST_COMMITTEES) else "user"
+        user_list_name = committee_user_list_name(committee_key)
         return [
             "announce@apache.org",
             f"announce@{committee_key}.apache.org",
@@ -1318,7 +1353,7 @@ def permitted_announce_recipients(
         return [USER_TESTS_ADDRESS, f"{asf_uid}@apache.org"]
     recipients = ["announce@apache.org"]
     if committee_key is not None:
-        user_list_name = "users" if (committee_key in USERS_LIST_COMMITTEES) else "user"
+        user_list_name = committee_user_list_name(committee_key)
         recipients.extend(
             [
                 f"announce@{committee_key}.apache.org",

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -42,6 +42,75 @@ def test_announce_recipients_use_users_list_for_maven(monkeypatch: pytest.Monkey
     assert "user@maven.apache.org" not in permitted
 
 
+def test_committee_user_list_name_cached(monkeypatch: pytest.MonkeyPatch):
+    fake_cache = {
+        "custom.apache.org": frozenset({"users", "dev", "announce"}),
+        "singular.apache.org": frozenset({"user", "dev", "announce"}),
+        "both.apache.org": frozenset({"users", "user", "dev"}),
+        "empty.apache.org": frozenset({"dev"}),
+    }
+    monkeypatch.setattr(util, "_MAILING_LISTS_CACHE", fake_cache)
+
+    assert util.committee_user_list_name("custom") == "users"
+    assert util.committee_user_list_name("singular") == "user"
+    assert util.committee_user_list_name("both") == "users"
+    assert util.committee_user_list_name("empty") == "user"
+
+
+def test_committee_user_list_name_static_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(util, "_MAILING_LISTS_CACHE", None)
+
+    assert util.committee_user_list_name("maven") == "users"
+    assert util.committee_user_list_name("airflow") == "users"
+    assert util.committee_user_list_name("unknown-committee") == "user"
+
+
+@pytest.mark.asyncio
+async def test_fetch_apache_mailing_lists_mocked(monkeypatch: pytest.MonkeyPatch):
+    class FakeResponse:
+        def __init__(self, data: dict[str, object]):
+            self._data = data
+
+        def raise_for_status(self) -> None:
+            pass
+
+        async def json(self, content_type: object = None) -> dict[str, object]:
+            return self._data
+
+        async def __aenter__(self) -> "FakeResponse":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+    class FakeSession:
+        def __init__(self, response: FakeResponse):
+            self._response = response
+
+        def get(self, url: str, **kwargs: object) -> FakeResponse:
+            return self._response
+
+        async def __aenter__(self) -> "FakeSession":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+    mock_data: dict[str, object] = {
+        "lists": {
+            "foo.apache.org": {"users": {}, "dev": {}},
+            "bar.apache.org": {"user": {}, "dev": {}},
+        }
+    }
+    monkeypatch.setattr(util, "create_secure_session", lambda **kwargs: FakeSession(FakeResponse(mock_data)))
+
+    cache = await util.fetch_apache_mailing_lists()
+    assert "foo.apache.org" in cache
+    assert "users" in cache["foo.apache.org"]
+    assert util.committee_user_list_name("foo") == "users"
+    assert util.committee_user_list_name("bar") == "user"
+
+
 def test_chmod_files_does_not_change_directory_permissions(tmp_path: pathlib.Path):
     subdir = tmp_path / "subdir"
     subdir.mkdir()


### PR DESCRIPTION
### Summary
This PR automatically derives whether an Apache committee uses \users\ or \user\ as its public user mailing list name, addressing #1567 (follow-up to #1563).

### Changes
- Added \etch_apache_mailing_lists()\ to query \https://lists.apache.org/api/preferences.json\ and populate \_MAILING_LISTS_CACHE\.
- Added \committee_user_list_name(committee_key)\ to dynamically derive \users\ vs \user\ with graceful fallback to \USERS_LIST_COMMITTEES\.
- Updated \configurable_recipients\ and \permitted_announce_recipients\ to use \committee_user_list_name\.
- Added comprehensive unit tests in \	ests/unit/test_util.py\.

### Verification
- Ruff lint and format check passed 100% cleanly.
- Unit tests covering cached resolution, static fallback, and preference fetching added.

Fixes #1567