### PR TITLE
Fix release announcement recipients and sandboxed rsync uploads

### DIFF
--- a/atr/ssh.py
+++ b/atr/ssh.py
@@ -290,11 +290,12 @@ async def server_stop(server: asyncssh.SSHAcceptor) -> None:
     log.info("SSH server stopped")
 
 
-def _build_rsync_write_argv(argv: list[str], path: safe.StatePath) -> list[str]:
+def _build_rsync_write_argv(argv: list[str]) -> list[str]:
     """Build the rsync command for a write, adding enforced server side limits."""
     if len(argv) < 2 or argv[-2] != ".":
         raise RuntimeError("Validated rsync write argv must end with '.' and the destination path")
-    return [*argv[:-2], f"--max-size={_RSYNC_MAX_UPLOAD_SIZE}", "--info=skip2", ".", str(path)]
+    # Use exactly '.' so rsync does not reopen ancestors outside the Landlock sandbox
+    return [*argv[:-2], f"--max-size={_RSYNC_MAX_UPLOAD_SIZE}", "--info=skip2", ".", "."]
 
 
 async def _drain_stderr(stream: asyncio.StreamReader) -> bytes:
@@ -677,13 +678,13 @@ async def _step_07b_process_validated_rsync_write(
             nonlocal exit_status
             if old_rev is not None:
                 log.info(f"Using old revision {old_rev.number} and interim path {path}")
-            rsync_argv = _build_rsync_write_argv(argv, path)
+            rsync_argv = _build_rsync_write_argv(argv)
             rsync_argv = sandbox.command(rsync_argv, rw_paths=[str(path)])
 
             ###################################################
             ### Calls _step_08_execute_rsync_upload_command ###
             ###################################################
-            exit_status = await _step_08_execute_rsync(process, rsync_argv)
+            exit_status = await _step_08_execute_rsync(process, rsync_argv, cwd=path)
             if exit_status != 0:
                 if old_rev is not None:
                     for_revision = f"successor of revision {old_rev.number}"
@@ -757,7 +758,9 @@ async def _step_07c_ensure_release_object_for_write(project_key: safe.ProjectKey
         await data.commit()
 
 
-async def _step_08_execute_rsync(process: asyncssh.SSHServerProcess, argv: list[str]) -> int:
+async def _step_08_execute_rsync(
+    process: asyncssh.SSHServerProcess, argv: list[str], *, cwd: safe.StatePath | None = None
+) -> int:
     """Execute the modified rsync command."""
     log.info(f"Executing modified rsync command: {' '.join(argv)}")
     proc = await asyncio.create_subprocess_exec(
@@ -765,6 +768,7 @@ async def _step_08_execute_rsync(process: asyncssh.SSHServerProcess, argv: list[
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
     )
     stderr_stream = proc.stderr
     drain = asyncio.create_task(_drain_stderr(stderr_stream)) if stderr_stream is not None else None

--- a/atr/tasks/message.py
+++ b/atr/tasks/message.py
@@ -96,7 +96,9 @@ def _verify_recipients(task_args: args.Send, sender_asf_uid: str) -> None:
         sending_to_self = addr == f"{sender_asf_uid}@apache.org"
         # audit_guidance we intentionally allow users to send messages to committees they are not a part of
         sending_to_committee = recipient_domain.endswith(".apache.org")
-        if not (sending_to_self or sending_to_committee):
+        # The foundation announcement list is on the root domain, unlike committee lists
+        sending_to_announce = addr == "announce@apache.org"
+        if not (sending_to_self or sending_to_committee or sending_to_announce):
             raise SendError(f"You are not permitted to send emails to {addr}")
 
 

--- a/tests/unit/test_manager_terminate.py
+++ b/tests/unit/test_manager_terminate.py
@@ -78,6 +78,8 @@ async def test_stop_worker_kills_the_group_when_a_child_survives(monkeypatch: py
 
 async def test_stop_worker_reports_a_child_which_outlives_the_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(manager, "_live_process_group_members", lambda pgid: [123])
+    killpg = mock.Mock()
+    monkeypatch.setattr("os.killpg", killpg)
     monkeypatch.setattr(manager, "_KILL_WAIT_SECONDS", 0.05)
     monkeypatch.setattr(manager, "_KILL_POLL_SECONDS", 0.01)
     errors = []
@@ -86,6 +88,7 @@ async def test_stop_worker_reports_a_child_which_outlives_the_deadline(monkeypat
 
     await manager.WorkerManager().stop_worker(worker_process)
 
+    assert killpg.call_args_list == [mock.call(999, signal.SIGTERM), mock.call(999, signal.SIGKILL)]
     assert len(errors) == 1
     assert "live members after SIGKILL" in errors[0]
     assert worker_process.stopping is False
@@ -105,6 +108,8 @@ async def test_stop_worker_waits_for_a_child_which_is_slow_to_die(monkeypatch: p
     # The child is still listed for the first few looks after SIGKILL, as it is in reality
     looks = [[123], [123], [123], []]
     monkeypatch.setattr(manager, "_live_process_group_members", lambda pgid: looks.pop(0) if looks else [])
+    killpg = mock.Mock()
+    monkeypatch.setattr("os.killpg", killpg)
     monkeypatch.setattr(manager, "_KILL_POLL_SECONDS", 0.01)
     errors = []
     monkeypatch.setattr(manager.log, "error", lambda message: errors.append(message))
@@ -112,6 +117,7 @@ async def test_stop_worker_waits_for_a_child_which_is_slow_to_die(monkeypatch: p
 
     await manager.WorkerManager().stop_worker(worker_process)
 
+    assert killpg.call_args_list == [mock.call(999, signal.SIGTERM), mock.call(999, signal.SIGKILL)]
     assert errors == []
     assert worker_process.stopping is True
 

--- a/tests/unit/test_message.py
+++ b/tests/unit/test_message.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Tests for ASF ID validation in atr.tasks.message module."""
+"""Tests for sender and recipient validation in atr.tasks.message module."""
 
 import contextlib
 import unittest.mock as mock
@@ -144,6 +144,31 @@ async def test_send_rejects_invalid_asf_id(monkeypatch: "MonkeyPatch") -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("recipient_field", ["email_to", "email_cc", "email_bcc"])
+@pytest.mark.parametrize("recipient", ["otheruser@apache.org", "announce@example.org", "announce@notapache.org"])
+async def test_send_rejects_unauthorized_recipients(
+    monkeypatch: "MonkeyPatch", recipient_field: str, recipient: str
+) -> None:
+    monkeypatch.setattr(
+        "atr.tasks.message.ldap.account_lookup",
+        mock.AsyncMock(
+            return_value=ldap.Result(
+                dn="uid=validuser,ou=people,dc=apache,dc=org", uid=["validuser"], cn=["Valid User"]
+            )
+        ),
+    )
+    mock_storage_write = mock.MagicMock()
+    monkeypatch.setattr("atr.tasks.message.storage.write", mock_storage_write)
+    task_args = _send_args()
+    task_args[recipient_field] = recipient if (recipient_field == "email_to") else [recipient]
+
+    with pytest.raises(message.SendError, match="You are not permitted to send emails"):
+        await message.send(task_args)
+
+    mock_storage_write.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_returns_warnings_on_partial_failure(monkeypatch: "MonkeyPatch") -> None:
     monkeypatch.setattr(
         "atr.tasks.message.ldap.account_lookup",
@@ -176,8 +201,12 @@ async def test_send_returns_warnings_on_partial_failure(monkeypatch: "MonkeyPatc
 
 
 @pytest.mark.asyncio
-async def test_send_succeeds_with_valid_asf_id(monkeypatch: "MonkeyPatch") -> None:
-    """Test that a valid ASF UID passes LDAP validation and sends the email."""
+@pytest.mark.parametrize("recipient_field", ["email_to", "email_cc", "email_bcc"])
+@pytest.mark.parametrize("recipient", ["dev@project.apache.org", "validuser@apache.org", "announce@apache.org"])
+async def test_send_succeeds_with_valid_asf_id(
+    monkeypatch: "MonkeyPatch", recipient_field: str, recipient: str
+) -> None:
+    """A valid ASF sender can deliver to each permitted recipient in any envelope field."""
     # ldap.account_lookup returns a dict for a known UID
     monkeypatch.setattr(
         "atr.tasks.message.ldap.account_lookup",
@@ -197,12 +226,14 @@ async def test_send_succeeds_with_valid_asf_id(monkeypatch: "MonkeyPatch") -> No
     mock_write.as_foundation_committer.return_value = mock_wafc
 
     @contextlib.asynccontextmanager
-    async def mock_storage_write(_asf_uid: str):  # type: ignore[no-untyped-def]
+    async def mock_storage_write(_asf_uid: str) -> AsyncIterator[mock.MagicMock]:
         yield mock_write
 
     monkeypatch.setattr("atr.tasks.message.storage.write", mock_storage_write)
 
-    result = await message.send(_send_args(email_sender="validuser@apache.org"))
+    task_args = _send_args(email_to="private@project.apache.org")
+    task_args[recipient_field] = recipient if (recipient_field == "email_to") else [recipient]
+    result = await message.send(task_args)
 
     # Verify the result
     assert result is not None
@@ -210,7 +241,9 @@ async def test_send_succeeds_with_valid_asf_id(monkeypatch: "MonkeyPatch") -> No
     assert result.mail_send_warnings == []
 
     # Verify mail.send was called exactly once
-    mock_mail_send.assert_called_once()
+    mock_mail_send.assert_awaited_once()
+    sent_message = mock_mail_send.call_args.args[0]
+    assert getattr(sent_message, recipient_field) == task_args[recipient_field]
 
 
 def test_send_task_args_omits_only_empty_message_id() -> None:

--- a/tests/unit/test_ssh_rsync_write.py
+++ b/tests/unit/test_ssh_rsync_write.py
@@ -19,19 +19,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import atr.ssh as ssh
 
-if TYPE_CHECKING:
-    import pathlib
 
-
-def test_build_rsync_write_argv_adds_server_side_limits(tmp_path: pathlib.Path) -> None:
+def test_build_rsync_write_argv_adds_server_side_limits() -> None:
     argv = ["rsync", "--server", "-vlogDtpre.iLsfxCIvu", "--delete", ".", "/proj/v1/"]
-    path = tmp_path / "atr-write" / "revision"
 
-    result = ssh._build_rsync_write_argv(argv, path)
+    result = ssh._build_rsync_write_argv(argv)
 
     assert result == [
         "rsync",
@@ -41,6 +35,6 @@ def test_build_rsync_write_argv_adds_server_side_limits(tmp_path: pathlib.Path) 
         f"--max-size={ssh._RSYNC_MAX_UPLOAD_SIZE}",
         "--info=skip2",
         ".",
-        str(path),
+        ".",
     ]
     assert argv == ["rsync", "--server", "-vlogDtpre.iLsfxCIvu", "--delete", ".", "/proj/v1/"]


### PR DESCRIPTION
## Pull request summary

**Meaningful subject (required):** Fix release announcement recipients and sandboxed rsync uploads

**Description:**

Release announcements addressed to `announce@apache.org` pass the announcement form and storage validation, but the queued message task rejects them with `You are not permitted to send emails to announce@apache.org`. Allow that exact address in the worker's recipient validation, while preserving sender validation and restrictions on other root-domain accounts and external recipients. Cover permitted and rejected recipients in To, Cc, and Bcc, including rejection before the mail writer runs.

The Build and test workflow also exposed an independent rsync upload failure: the Alpine image now installs rsync 3.5.0, whose receiver opens each ancestor of an absolute destination path. Landlock denies access to those ancestors, so uploads exit with code 3. Start the upload subprocess in its quarantine directory and use exactly `.` as the receiver destination. This avoids reopening ancestors while preserving the existing sandbox grants, upload limits, and read behavior. The existing Playwright SSH upload test covers this regression.

Two worker-termination tests used a fake process group (`999`) without mocking `os.killpg`, so they could send real signals and fail with `PermissionError` depending on the runner. Mock signal delivery in both tests and assert the expected SIGTERM/SIGKILL sequence, preserving their deadline and surviving-child assertions.

## Validation

- The announcement regression failed before the recipient fix; all 26 message tests pass afterward.
- `uv run --frozen pytest -rs tests`: 2266 passed, 29 skipped.
- With a temporary fixture simulating permission-denied process-group signals, the termination tests reproduced the two CI failures before the test fix; all 10 pass afterward, on both macOS and Linux with the locked pytest and pytest-asyncio versions.
- `make check`: all checks passed.
- `docker build -t atr-pr1592-ci-fix -f Dockerfile.alpine .`: passed, with rsync 3.5.0 in the runtime image.
- Reproduced the rsync code 3 failure in the Linux runtime image with an absolute destination. The same sandboxed transfer passes with the destination set to `.` and the subprocess working directory set to the upload directory, including nested files.
- `playwright/test.py --skip-slow`: all tests passed against the rebuilt Linux application container, including the previously failing SSH upload. Verified with both the local macOS runner and a Linux runner using GNU rsync 3.2.7 (the same client version as CI). The Linux runner used cached Chromium with Playwright 1.61.0; the application image used rsync 3.5.0.
- All five existing sandbox tests passed in the Linux runtime image. A transfer through a symlink to a directory outside the sandbox was also rejected, with the outside file unchanged.
- The separate `tests/e2e/` suite was previously run against this branch: 109 passed, 7 skipped, 1 failed. Its sole failure, `test_announce_archives_prior_release`, also fails at the same archived-card assertion against unmodified `main` (`0ed47e0e`). This is separate from the Playwright workflow failure fixed here.
- All GitHub checks pass for commit `3285b72b`: [Build and test](https://github.com/apache/tooling-trusted-releases/actions/runs/34619580703), [pre-commit analysis](https://github.com/apache/tooling-trusted-releases/actions/runs/34619580709), and [CodeQL](https://github.com/apache/tooling-trusted-releases/actions/runs/34619580267). The hosted Playwright suite, including the SSH upload, completed successfully.

## Required acknowledgements

- [x] I have read and followed **CONTRIBUTING.md**
- [x] I have read **DEVELOPMENT.md**
- [x] I have run the required tests and checks locally
- [ ] All required checks are currently passing (GitHub CI passes; the separate pre-existing local e2e failure is documented above)
- [x] This branch is **rebased on the current `main` branch**

## Rebase confirmation details

The branch is based on `origin/main` at `0ed47e0e`. The rsync correction and worker-test isolation are separate follow-up commits.
